### PR TITLE
test & CI changes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,5 +12,6 @@ dependencies:
 
 test:
   override:
-    - docker run -e "MIX_ENV=test" panacea mix test
+    - mkdir -p $CIRCLE_TEST_REPORTS/exunit
+    - docker run -e "MIX_ENV=test" -e "CI=true" -v $CIRCLE_TEST_REPORTS/exunit:/test-reports panacea /bin/bash -c "mix test; cp _build/test/lib/panacea/test-junit-report.xml /test-reports"
 

--- a/panacea/mix.exs
+++ b/panacea/mix.exs
@@ -34,6 +34,8 @@ defmodule Panacea.Mixfile do
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
-     {:phoenix_integration, "~> 0.2", only: :test}]
+     {:phoenix_integration, "~> 0.2", only: :test},
+     {:junit_formatter, ">= 0.0.0", only: :test}
+   ]
   end
 end

--- a/panacea/mix.lock
+++ b/panacea/mix.lock
@@ -4,6 +4,7 @@
   "floki": {:hex, :floki, "0.14.0", "91a6be57349e10a63cf52d7890479a19012cef9185fa93c305d4fe42e6a50dee", [:mix], [{:mochiweb, "~> 2.15", [hex: :mochiweb, optional: false]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], []},
+  "junit_formatter": {:hex, :junit_formatter, "1.3.0", "e4321e3275f48daecadb3116bc814e1a743645f2549c6526b1a32cd6c8dd1833", [:mix], []},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
   "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], []},
   "phoenix": {:hex, :phoenix, "1.2.1", "6dc592249ab73c67575769765b66ad164ad25d83defa3492dc6ae269bd2a68ab", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},

--- a/panacea/test/support/channel_case.ex
+++ b/panacea/test/support/channel_case.ex
@@ -26,7 +26,7 @@ defmodule Panacea.ChannelCase do
     end
   end
 
-  setup tags do
+  setup _tags do
 
     :ok
   end

--- a/panacea/test/support/conn_case.ex
+++ b/panacea/test/support/conn_case.ex
@@ -27,7 +27,7 @@ defmodule Panacea.ConnCase do
     end
   end
 
-  setup tags do
+  setup _tags do
 
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end

--- a/panacea/test/test_helper.exs
+++ b/panacea/test/test_helper.exs
@@ -1,2 +1,10 @@
+formatters = [ExUnit.CLIFormatter]
+
+if System.get_env("CI") do
+  ExUnit.start formatters: [JUnitFormatter|formatters]
+else
+  ExUnit.start formatters: formatters
+end
+
 ExUnit.start
 


### PR DESCRIPTION
- removes `unused variable X` warnings from test/support templates

- when run with the env var CI set, the tests now produce a JUnit style XML report

Without this report, Circle only knows whether the tests passed/failed. The report gives it some insight, so notifications etc are improved.

The report has to be copied from the container to a specific directory on the circle host machine. Atm that's done with docker volumes, perhaps there is a better approach?