### PR TITLE
ui changes

### DIFF
--- a/athloi/features/step_definitions/file_upload_steps.rb
+++ b/athloi/features/step_definitions/file_upload_steps.rb
@@ -3,7 +3,7 @@ When(/^I submit the upload form$/) do
 end
 
 Then(/^I should see the found drugs panel$/) do
-  panel = find('#drugs-panel')
+  panel = find('#drugs-panel', wait: 15)
 
   expect(panel).to be_visible
 end

--- a/panacea/web/static/js/app.js
+++ b/panacea/web/static/js/app.js
@@ -14,7 +14,7 @@ async function submitFile() {
   View.hideFileForm();
   View.hideResults();
   try {
-    handleDrugsResponse(await Request.drugs(new FormData(this)));
+    await handleDrugsResponse(await Request.drugs(new FormData(this)));
   } catch (e) {
     View.displayNetworkError(e);
   }
@@ -25,20 +25,20 @@ async function submitFile() {
 async function handleResponse(response, handle) {
   if (response.ok) {
     const payload = await response.json();
-    handle(payload);
+    await handle(payload);
   } else {
     const {error} = await response.json();
     View.displayError(error);
   }
 }
 
-const handleDrugsResponse = drugsResponse => {
-  handleResponse(drugsResponse, async function ({drugs}) {
+async function handleDrugsResponse(response) {
+  await handleResponse(response, async function ({drugs}) {
     const labels = drugs.map(x => x.label);
 
     if (labels.length > 0) {
       try {
-        handleUrisResponse(await Request.uris(labels));
+        await handleUrisResponse(await Request.uris(labels));
       } catch (e) {
         View.displayNetworkError(e);
       }
@@ -46,10 +46,10 @@ const handleDrugsResponse = drugsResponse => {
       View.displayNoDrugsError();
     }
   });
-};
+}
 
-const handleUrisResponse = urisResponse => {
-  handleResponse(urisResponse, async function ({uris: {found, not_found: unidentifiedDrugs}}) {
+async function handleUrisResponse(response) {
+  await handleResponse(response, async function ({uris: {found, not_found: unidentifiedDrugs}}) {
     const uris = found.map(x => x.uri);
     const labels = found.map(x => x.label);
 
@@ -61,7 +61,7 @@ const handleUrisResponse = urisResponse => {
 
     if (uris.length > 1) {
       try {
-        handleDdisResponse(await Request.ddis(uris));
+        await handleDdisResponse(await Request.ddis(uris));
       } catch (e) {
         View.displayNetworkError(e);
       }
@@ -69,10 +69,10 @@ const handleUrisResponse = urisResponse => {
       View.displayDdis([]);
     }
   });
-};
+}
 
-const handleDdisResponse = ddisResponse => {
-  handleResponse(ddisResponse, ({ddis}) => {
+async function handleDdisResponse(response) {
+  await handleResponse(response, ({ddis}) => {
     View.displayDdis(ddis);
   });
-};
+}

--- a/panacea/web/static/js/app.js
+++ b/panacea/web/static/js/app.js
@@ -37,14 +37,13 @@ const handleDrugsResponse = drugsResponse => {
     const labels = drugs.map(x => x.label);
 
     if (labels.length > 0) {
-      View.displayDrugs(labels);
       try {
         handleUrisResponse(await Request.uris(labels));
       } catch (e) {
         View.displayNetworkError(e);
       }
     } else {
-     View.displayError({title: "Pathway error", detail: "No drugs found"});
+      View.displayNoDrugsError();
     }
   });
 };
@@ -52,19 +51,22 @@ const handleDrugsResponse = drugsResponse => {
 const handleUrisResponse = urisResponse => {
   handleResponse(urisResponse, async function ({uris: {found, not_found: unidentifiedDrugs}}) {
     const uris = found.map(x => x.uri);
+    const labels = found.map(x => x.label);
+
+    View.displayDrugs(labels);
 
     if (unidentifiedDrugs.length > 0) {
       View.displayUnidentifiedDrugs(unidentifiedDrugs);
     }
 
-    if (uris.length >= 2) {
+    if (uris.length > 1) {
       try {
         handleDdisResponse(await Request.ddis(uris));
       } catch (e) {
         View.displayNetworkError(e);
       }
     } else {
-      console.log("by definition ddis require more than one drug");
+      View.displayDdis([]);
     }
   });
 };

--- a/panacea/web/static/js/view.js
+++ b/panacea/web/static/js/view.js
@@ -52,7 +52,15 @@ export const displayError = error => {
 export const displayNetworkError = error => {
   const title = "Network Error";
   const detail = `<h5>Something went wrong</h5><code>${error}<code>`;
-  displayError({title, detail})
+  displayError({title, detail});
+};
+
+export const displayNoDrugsError = () => {
+  const title = "Pathway Error";
+  const detail = `<h5>No drugs were found in the given file.
+You can specify drugs in PML like this:</h5>
+<code>requires { drug { "paracetamol" } }</code>`;
+  displayError({title, detail});
 };
 
 const formElement = document.getElementById('file-form');

--- a/panacea/web/static/js/view.js
+++ b/panacea/web/static/js/view.js
@@ -50,13 +50,13 @@ export const displayError = error => {
 };
 
 export const displayNetworkError = error => {
-  const title = "Network Error";
+  const title = "Network error";
   const detail = `<h5>Something went wrong</h5><code>${error}<code>`;
   displayError({title, detail});
 };
 
 export const displayNoDrugsError = () => {
-  const title = "Pathway Error";
+  const title = "Pathway error";
   const detail = `<h5>No drugs were found in the given file.
 You can specify drugs in PML like this:</h5>
 <code>requires { drug { "paracetamol" } }</code>`;


### PR DESCRIPTION
ui updates:

* don't display unidentified drugs in the `found drugs panel`
* give a more detailed error message when no labels are found in the document
* show an empty `DDIs panel` when fewer than 2 drugs are identified

spinner bug:

when we refactored the request chain we unfortunately lost an easy way to wait
for the chain to end. So the spinner would appear and disappear immediately
while the request chain did its work asynchronously.

Added `await` and `async function` to everything in the chain so we can get this
behaviour back.

Perhaps there's a cleaner solution.