### PR TITLE
PML AST and Analysis

### DIFF
--- a/athloi/features/fixtures/ddis.pml
+++ b/athloi/features/fixtures/ddis.pml
@@ -12,7 +12,7 @@ process foo {
     action baz2 {
       tool { "pills" }
       script { "eat the pills" }
-      agent { "patient" }
+      agent { (intangible)(inscrutable) pml.wtf && ("foo" || 1 != 2) }
       requires {
         drug { "trandolapril" }
       }

--- a/panacea/lib/panacea/pml/analysis.ex
+++ b/panacea/lib/panacea/pml/analysis.ex
@@ -8,7 +8,7 @@ defmodule Panacea.Pml.Analysis do
   end
 
   defp analyse(result, {:drug, [line: line], label}) do
-    %{result| drugs: [ %{label: label, line: line}| result.drugs ]}
+    %{result| drugs: [ %{label: to_string(label), line: line}| result.drugs ]}
   end
   defp analyse(result, {_, _,children}) when is_list(children) do
     Enum.reduce(children, result, fn(child, acc) ->

--- a/panacea/lib/panacea/pml/analysis.ex
+++ b/panacea/lib/panacea/pml/analysis.ex
@@ -8,7 +8,7 @@ defmodule Panacea.Pml.Analysis do
   end
 
   defp analyse(result, {:drug, [line: line], label}) do
-    %{result| drugs: [ %{label: to_string(label), line: line}| result.drugs ]}
+    %{result| drugs: [ %{label: strip_quotes(label), line: line}| result.drugs ]}
   end
   defp analyse(result, {_, _,children}) when is_list(children) do
     Enum.reduce(children, result, fn(child, acc) ->
@@ -19,6 +19,12 @@ defmodule Panacea.Pml.Analysis do
     analyse(result, child)
   end
   defp analyse(result, _), do: result
+
+  defp strip_quotes(char_list) do
+    char_list
+    |> :string.strip(:both, ?")
+    |> to_string()
+  end
 
   def test do
     {:ok, ast} = Panacea.Pml.Parser.test

--- a/panacea/lib/panacea/pml/analysis.ex
+++ b/panacea/lib/panacea/pml/analysis.ex
@@ -1,0 +1,27 @@
+defmodule Panacea.Pml.Analysis do
+  alias __MODULE__
+
+  defstruct drugs: []
+
+  def run(ast) do
+    {:ok, analyse(%Analysis{}, ast)}
+  end
+
+  defp analyse(result, {:drug, [line: line], label}) do
+    %{result| drugs: [ %{label: label, line: line}| result.drugs ]}
+  end
+  defp analyse(result, {_, _,children}) when is_list(children) do
+    Enum.reduce(children, result, fn(child, acc) ->
+      analyse(acc, child)
+    end)
+  end
+  defp analyse(result, {_, _,child}) do
+    analyse(result, child)
+  end
+  defp analyse(result, _), do: result
+
+  def test do
+    {:ok, ast} = Panacea.Pml.Parser.test
+    run(ast)
+  end
+end

--- a/panacea/lib/panacea/pml/analysis.ex
+++ b/panacea/lib/panacea/pml/analysis.ex
@@ -25,9 +25,4 @@ defmodule Panacea.Pml.Analysis do
     |> :string.strip(:both, ?")
     |> to_string()
   end
-
-  def test do
-    {:ok, ast} = Panacea.Pml.Parser.test
-    run(ast)
-  end
 end

--- a/panacea/lib/panacea/pml/ast.ex
+++ b/panacea/lib/panacea/pml/ast.ex
@@ -1,0 +1,38 @@
+defmodule Panacea.Pml.Ast do
+  @multi_line_constructs ~w(process action task sequence selection branch iteration)a
+  @single_line_constructs ~w(requires provides agent tool script input output)a
+
+  @doc """
+  Takes an AST and returns the PML it represents in an IO-List
+  """
+  def to_pml(ast) do
+    do_unquote(ast, 0)
+  end
+
+  defp do_unquote({type, attrs, children}, depth) when type in @multi_line_constructs do
+    optional_name = get_with_default(attrs, :name)
+    optional_type = get_with_default(attrs, :type)
+
+    [indent(depth), to_string(type), optional_name, optional_type, " {\n",
+     Enum.map(children, fn(child) -> [do_unquote(child, depth + 1), "\n"] end),
+     indent(depth), "}"
+    ]
+  end
+
+  defp do_unquote({type, _, value}, depth) when type in @single_line_constructs do
+    [indent(depth), to_string(type), " { ", do_unquote(value), " }"]
+  end
+
+  defp do_unquote({:expression, _, value}), do: value
+  defp do_unquote({:drug, _, value}), do: ["drug { ", value, " }"]
+  defp do_unquote(x) when is_list(x), do: x
+
+  defp indent(depth), do: String.duplicate(" ", 2 * depth)
+
+  defp get_with_default(attrs, key) do
+    case Keyword.get(attrs, key) do
+      nil -> ""
+      x   -> [" ", x]
+    end
+  end
+end

--- a/panacea/lib/panacea/pml/parser.ex
+++ b/panacea/lib/panacea/pml/parser.ex
@@ -33,13 +33,4 @@ defmodule Panacea.Pml.Parser do
     Logger.info("PML Analysis success")
     {:ok, ast}
   end
-
-  def test do
-    {:ok, f} = File.read("test/fixtures/ddis.pml")
-    f
-    |> to_charlist()
-    |> :pml_lexer.string()
-    |> elem(1)
-    |> :pml_parser.parse()
-  end
 end

--- a/panacea/lib/panacea/pml/parser.ex
+++ b/panacea/lib/panacea/pml/parser.ex
@@ -36,4 +36,13 @@ defmodule Panacea.Pml.Parser do
 
     {:ok, result}
   end
+
+  def test do
+    {:ok, f} = File.read("test/fixtures/ddis.pml")
+    f
+    |> to_charlist()
+    |> :pml_lexer.string()
+    |> elem(1)
+    |> :pml_parser.parse()
+  end
 end

--- a/panacea/lib/panacea/pml/parser.ex
+++ b/panacea/lib/panacea/pml/parser.ex
@@ -8,33 +8,30 @@ defmodule Panacea.Pml.Parser do
     str
     |> to_charlist()
     |> tokens()
-    |> do_parse()
-    |> to_result()
+    |> generate_ast()
+    |> log_result()
   end
 
   defp tokens(str) do
     :pml_lexer.string(str)
   end
 
-  defp do_parse({:ok, tokens, _}) do
+  defp generate_ast({:ok, tokens, _}) do
     :pml_parser.parse(tokens)
   end
-  defp do_parse({:error, reason, _}) do
+  defp generate_ast({:error, reason, _}) do
     {:error, reason}
   end
 
-  defp to_result({:error, reason}) do
+  defp log_result({:error, reason}) do
     formatted = Error.format(reason)
     Logger.error("PML Parsing error: #{formatted}")
 
     {:error, {:syntax_error, formatted}}
   end
-  defp to_result({:ok, drugs}) do
-    result = for {label, line} <- drugs, do: %{label: label, line: line}
-
-    Logger.info(["PML Parsing success: ", inspect(result)])
-
-    {:ok, result}
+  defp log_result({:ok, ast}) do
+    Logger.info("PML Analysis success")
+    {:ok, ast}
   end
 
   def test do

--- a/panacea/src/pml_lexer.xrl
+++ b/panacea/src/pml_lexer.xrl
@@ -50,7 +50,7 @@ executable    : {token, {executable, TokenLine}}.
 {COMMENT}     : skip_token.
 {WS}          : skip_token.
 {STRING}      : {token, {string, TokenLine, TokenChars}}.
-{NUMBER}      : {token, {number, TokenLine}}.
+{NUMBER}      : {token, {number, TokenLine, TokenChars}}.
 {IDENT}       : {token, {ident, TokenLine, TokenChars}}.
 
 Erlang code.

--- a/panacea/src/pml_lexer.xrl
+++ b/panacea/src/pml_lexer.xrl
@@ -51,6 +51,6 @@ executable    : {token, {executable, TokenLine}}.
 {WS}          : skip_token.
 {STRING}      : {token, {string, TokenLine, TokenChars}}.
 {NUMBER}      : {token, {number, TokenLine}}.
-{IDENT}       : {token, {ident, TokenLine}}.
+{IDENT}       : {token, {ident, TokenLine, TokenChars}}.
 
 Erlang code.

--- a/panacea/src/pml_parser.yrl
+++ b/panacea/src/pml_parser.yrl
@@ -151,9 +151,9 @@ value -> variable           : '$1'.
 variable -> ident accessor              : function_application('$1', '$2').
 variable -> prefix prefix_list accessor : function_application(['$1'|'$2'], '$3').
 
-prefix -> '(' ident ')' : {prefix, extract_string('$2')}.
+prefix -> '(' ident ')' : {prefix, [], extract_string('$2')}.
 
-prefix_list -> ident              : [{ident, extract_string('$1')}].
+prefix_list -> ident              : [{ident, [], extract_string('$1')}].
 prefix_list -> prefix prefix_list : ['$1'|'$2'].
 prefix_list -> '$empty'           : [].
 

--- a/panacea/src/pml_parser.yrl
+++ b/panacea/src/pml_parser.yrl
@@ -117,16 +117,16 @@ action_attribute ->
 action_attribute ->
     agent '{' expression '}'       : construct('$1', [], '$3').
 action_attribute ->
-    script '{' string '}'          : construct('$1', [], extract_string('$3')).
+    script '{' string '}'          : construct('$1', [], value_of('$3')).
 action_attribute ->
-    tool '{' string '}'            : construct('$1', [], extract_string('$3')).
+    tool '{' string '}'            : construct('$1', [], value_of('$3')).
 action_attribute ->
-    input '{' string '}'           : construct('$1', [], extract_string('$3')).
+    input '{' string '}'           : construct('$1', [], value_of('$3')).
 action_attribute ->
-    output '{' string '}'          : construct('$1', [], extract_string('$3')).
+    output '{' string '}'          : construct('$1', [], value_of('$3')).
 
 requires_expr ->
-    drug '{' string '}'            : construct('$1', [], extract_string('$3')).
+    drug '{' string '}'            : construct('$1', [], value_of('$3')).
 
 requires_expr ->
     expression : '$1'.
@@ -144,7 +144,7 @@ operation -> '$empty'       : "".
 
 value -> '!' expression     : "!" ++ value_of('$2').
 value -> '(' expression ')' : "(" ++ value_of('$2') ++ ")".
-value -> string             : extract_string('$1').
+value -> string             : value_of('$1').
 value -> number             : value_of('$1').
 value -> variable           : '$1'.
 
@@ -171,9 +171,6 @@ Erlang code.
 
 value_of({_, _, Value}) ->
     Value.
-
-extract_string({_, _, Str}) ->
-    string:strip(Str, both, $").
 
 construct({Type, Line}, Attributes, Value) ->
     Attrs = lists:filter(fun({_,X}) -> X /= nil end, Attributes),

--- a/panacea/test/controllers/pml_controller_test.exs
+++ b/panacea/test/controllers/pml_controller_test.exs
@@ -51,8 +51,8 @@ defmodule Panacea.PmlControllerTest do
 
       assert conn.status == 200
       assert response_body(conn) |> Map.get("drugs") == [
-        %{"label" => "paracetamol", "line" => 8},
-        %{"label" => "cocaine", "line" => 17}
+        %{"label" => "cocaine", "line" => 17},
+        %{"label" => "paracetamol", "line" => 8}
       ]
     end
   end

--- a/panacea/test/fixtures/ddis.pml
+++ b/panacea/test/fixtures/ddis.pml
@@ -12,7 +12,7 @@ process foo {
     action baz2 {
       tool { "pills" }
       script { "eat the pills" }
-      agent { "patient" }
+      agent { (intangible)(inscrutable) pml.wtf && ("foo" || 1 != 2) }
       requires {
         drug { "trandolapril" }
       }

--- a/panacea/test/fixtures/jnolls_pml/edit-compile-test.pml
+++ b/panacea/test/fixtures/jnolls_pml/edit-compile-test.pml
@@ -6,7 +6,7 @@ process develop {
 	}
 	action compile manual {
 	    requires { code.status == modified }
-	    provides { progA.type == executable }
+	    provides { progA.type == "executable" }
 	}
 	action test manual {
 	    requires { progA }

--- a/panacea/test/fixtures/jnolls_pml/sample.pml
+++ b/panacea/test/fixtures/jnolls_pml/sample.pml
@@ -6,7 +6,7 @@ process develop {
 		}
 		action compile manual {
 			requires { code.status == modified }
-			provides { progA.type == executable }
+			provides { progA.type == "executable "}
 		}
 		action test manual {
 			requires { progA }

--- a/panacea/test/fixtures/jnolls_pml/sample2.pml
+++ b/panacea/test/fixtures/jnolls_pml/sample2.pml
@@ -7,7 +7,7 @@ process example {
 			}
 			action compile {
 				requires { code.status == modified }
-				provides { progA.type == executable }
+				provides { progA.type == "executable "}
 			}
 		}
 		sequence test {

--- a/panacea/test/panacea/pml/analysis_test.exs
+++ b/panacea/test/panacea/pml/analysis_test.exs
@@ -1,0 +1,41 @@
+defmodule Panacea.Pml.AnalysisTest do
+  use ExUnit.Case
+
+  describe "run/1" do
+    test "it identifies drugs in the AST" do
+      pml = """
+      process foo {
+        task bar {
+          action baz {
+            tool { "pills" }
+            script { "eat the pills" }
+            agent { "patient" }
+            requires {
+              drug { "paracetamol" }
+            }
+            provides { "a cured patient" }
+          }
+          action baz2 {
+            tool { "pills" }
+            script { "eat the pills" }
+            agent { "patient" }
+            requires {
+              drug { "cocaine" }
+            }
+            provides { "a cured patient" }
+          }
+        }
+      }
+      """
+
+      {:ok, ast} = Panacea.Pml.Parser.parse(pml)
+      {:ok, analysis} = Panacea.Pml.Analysis.run(ast)
+
+      assert analysis.drugs ==
+        [
+          %{label: "cocaine", line: 17},
+          %{label: "paracetamol", line: 8}
+        ]
+    end
+  end
+end

--- a/panacea/test/panacea/pml/ast_test.exs
+++ b/panacea/test/panacea/pml/ast_test.exs
@@ -1,0 +1,34 @@
+defmodule Panacea.Pml.AstTest do
+  use ExUnit.Case
+
+  describe "to_pml/2" do
+    test "it returns the correct PML" do
+      pml = """
+      process foo {
+        task bar {
+          action baz {
+            tool { "pills" }
+            script { "eat the pills" }
+            agent { "patient" }
+            requires { drug { "torasemide" } }
+            provides { "a cured patient" }
+          }
+          action baz2 {
+            tool { "pills" }
+            script { "eat the pills" }
+            agent { (intangible) (inscrutable) pml.wtf && ("foo" || 1 != 2) }
+            requires { drug { "trandolapril" } }
+            provides { "a cured patient" }
+          }
+        }
+      }
+      """
+      |> String.replace_trailing("\n", "")
+
+      {:ok, ast} = Panacea.Pml.Parser.parse(pml)
+      generated_pml = Panacea.Pml.Ast.to_pml(ast) |> IO.chardata_to_string()
+
+      assert generated_pml == pml
+    end
+  end
+end

--- a/panacea/test/panacea/pml/parser_test.exs
+++ b/panacea/test/panacea/pml/parser_test.exs
@@ -21,7 +21,7 @@ defmodule Panacea.Pml.ParserTest do
       }
       """
 
-      assert Parser.parse(pml) == {:ok, []}
+      assert {:ok, _} = Parser.parse(pml)
     end
 
     test "it can parse all of jnoll's sample pml" do
@@ -40,42 +40,6 @@ defmodule Panacea.Pml.ParserTest do
       """
 
       assert Parser.parse(pml) == {:error,  {:syntax_error, "line 1 -- syntax error before: '{'"}}
-    end
-
-    test "it identifies drugs" do
-      pml = """
-        process foo {
-          task bar {
-            action baz {
-              tool { "pills" }
-              script { "eat the pills" }
-              agent { "patient" }
-              requires {
-                drug { "paracetamol" }
-              }
-              provides { "a cured patient" }
-            }
-            action baz2 {
-              tool { "pills" }
-              script { "eat the pills" }
-              agent { "patient" }
-              requires {
-                drug { "cocaine" }
-              }
-              provides { "a cured patient" }
-            }
-          }
-        }
-      """
-
-      assert Parser.parse(pml) ==
-      {
-        :ok,
-        [
-          %{label: "paracetamol", line: 8},
-          %{label: "cocaine", line: 17}
-        ]
-      }
     end
   end
 end

--- a/panacea/web/controllers/pml_controller.ex
+++ b/panacea/web/controllers/pml_controller.ex
@@ -6,6 +6,7 @@ defmodule Panacea.PmlController do
     |> File.read()
     |> validate()
     |> parse()
+    |> analyse()
     |> to_result()
     |> Panacea.BaseController.respond(conn)
   end
@@ -21,6 +22,9 @@ defmodule Panacea.PmlController do
   defp parse({:ok, contents}),  do: Panacea.Pml.Parser.parse(contents)
   defp parse({:error, reason}), do: {:error, reason}
 
-  defp to_result({:ok, drugs}),     do: {:ok, %{drugs: drugs}}
+  defp analyse({:ok, ast}), do: Panacea.Pml.Analysis.run(ast)
+  defp analyse({:error, reason}), do: {:error, reason}
+
+  defp to_result({:ok, analysis}),  do: {:ok, %{drugs: analysis.drugs}}
   defp to_result({:error, reason}), do: {:error, reason}
 end


### PR DESCRIPTION
This PR adds the framework for doing more detailed analysis on PML. Opening this for review and discussion.

Previously, the parser would look at the token stream generated by the lexer, and discard anything that wasn't a drug. Now we need to do more detailed analysis, so the parser turns the token stream into an Abstract Syntax Tree.

Each node in the AST has the structure: `{type, attributes, value}`

Where

- type is an atom identifying the type of node. e.g. `:process`
- attributes is a keyword list. e.g. `[line: 4, name: "foo"]`
- value is either a list of children or a primitive value. e.g.` [{..., ..., ...}, {..., ..., ...}]` or `"string"` or `"1234"`

For a larger example. The following PML:

```
process foo {
  task bar {
    action baz {
      tool { "pills" }
      script { "eat the pills" }
      agent { "patient" }
      requires {
        drug { "torasemide" }
      }
      provides { "a cured patient" }
    }
    action baz2 {
      tool { "pills" }
      script { "eat the pills" }
      agent { (intangible)(inscrutable) pml.wtf && ("foo" || 1 != 2) }
      requires {
        drug { "trandolapril" }
      }
      provides { "a cured patient" }
    }
  }
}
```

Becomes this AST:

```elixir
{:process, [line: 1, name: 'foo'],
  [{:task, [line: 2, name: 'bar'],
    [{:action, [line: 3, name: 'baz'],
      [{:tool, [line: 4], "pills"}, {:script, [line: 5], "eat the pills"},
       {:agent, [line: 6], "patient"},
       {:requires, [line: 7], {:drug, [line: 8], "torasemide"}},
       {:provides, [line: 10], "a cured patient"}]},
     {:action, [line: 12, name: 'baz2'],
      [{:tool, [line: 13], "pills"}, {:script, [line: 14], "eat the pills"},
       {:agent, [line: 15],
        {:&&, [line: 15],
         [{:., [line: 15],
           [[{:prefix, [], "intangible"}, {:prefix, [], "inscrutable"},
             {:ident, [], "pml"}], "wtf"]},
          {:parenthesised, [],
           {:||, [line: 15], ["foo", {:!=, [line: 15], ["1", "2"]}]}}]}},
       {:requires, [line: 16], {:drug, [line: 17], "trandolapril"}},
       {:provides, [line: 19], "a cured patient"}]}]}]}}
```

The `Analysis` module iterates over the AST performing analysis. This analysis can then be returned to the user. For now, it simply walks the AST and collects the drugs.