### PR TITLE
Ast endpoints

### DIFF
--- a/athloi/features/pml_download.feature
+++ b/athloi/features/pml_download.feature
@@ -1,0 +1,13 @@
+Feature: PML Download
+  In order to refine PML analysis
+  As a clinician
+  I should be able to download the PML file resulting from PML TX transformations
+
+  Background:
+    Given I am on the home page
+
+  Scenario: uploading a PML file with identifiable drugs
+    When I select "ddis.pml"
+    And I submit the upload form
+    And I click the PML Download button
+    Then I should get a download with the filename "pml-tx.pml"

--- a/athloi/features/pml_download.feature
+++ b/athloi/features/pml_download.feature
@@ -3,11 +3,9 @@ Feature: PML Download
   As a clinician
   I should be able to download the PML file resulting from PML TX transformations
 
-  Background:
+  Scenario: uploading a valid PML file
     Given I am on the home page
-
-  Scenario: uploading a PML file with identifiable drugs
     When I select "ddis.pml"
     And I submit the upload form
-    And I click the PML Download button
-    Then I should get a download with the filename "pml-tx.pml"
+    Then I should see the PML download button
+    And the PML download button should have the correct href

--- a/athloi/features/step_definitions/file_upload_steps.rb
+++ b/athloi/features/step_definitions/file_upload_steps.rb
@@ -1,7 +1,3 @@
-When(/^I submit the upload form$/) do
-  click_on 'Submit'
-end
-
 Then(/^I should see the found drugs panel$/) do
   panel = find('#drugs-panel', wait: 15)
 

--- a/athloi/features/step_definitions/pml_download_steps.rb
+++ b/athloi/features/step_definitions/pml_download_steps.rb
@@ -1,7 +1,12 @@
-When(/^I click the PML Download button$/) do
-  click_on 'Download PML TX File'
+Then(/^I should see the PML download button$/) do
+  button = find('#pml-download-anchor')
+
+  expect(button).to be_visible
 end
 
-Then(/^I should get a download with the filename "([^"]*)"$/) do |filename|
-  page.response_headers['Content-Disposition'].should include("filename=\"#{filename}\"")
+Then(/^the PML download button should have the correct href$/) do
+  button = find('#pml-download-anchor')
+
+  expect(button[:href]).to have_content('authorization_token=')
+  expect(button[:href]).to have_content('ast=')
 end

--- a/athloi/features/step_definitions/pml_download_steps.rb
+++ b/athloi/features/step_definitions/pml_download_steps.rb
@@ -1,0 +1,7 @@
+When(/^I click the PML Download button$/) do
+  click_on 'Download PML TX File'
+end
+
+Then(/^I should get a download with the filename "([^"]*)"$/) do |filename|
+  page.response_headers['Content-Disposition'].should include("filename=\"#{filename}\"")
+end

--- a/athloi/features/step_definitions/shared_steps.rb
+++ b/athloi/features/step_definitions/shared_steps.rb
@@ -10,3 +10,7 @@ When(/^I select "([^"]*)"$/) do |filename|
 
   execute_script("document.getElementById('file-input').classList.add('hidden')")
 end
+
+When(/^I submit the upload form$/) do
+  click_on 'Submit'
+end

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Added support for PML TX file downloads. Valid pml files uploaded to the
+  system for transformation can now be downloaded via the UI.
+
 ## [1.0] 2017-03-12
 
 ### Changed

--- a/doc/FEATURES.md
+++ b/doc/FEATURES.md
@@ -230,6 +230,18 @@ http://chiron:3030/dinto/query`) and the contents of those queries.
 
 See [On Screen DINTO Reporting](#on-screen-dinto-reporting---complete)
 
+## PML-TX Save PML to File - Complete
+
+### Description
+The system should be able to allow saving of transformed PML files.
+
+### Testing
+Visit the [homepage] and select a valid PML file; for example
+`panacea/text/fixtures/ddis.pml`. Press the `Submit` button. You should now see
+a `Download PML TX File` button. Clicking the button, depending on your
+browser, will either download the file automatically or prompt you to provide a
+filename and location and download the file.
+
 [README]: ../README.md
 [homepage]: http://localhost:4000
 [fixtures directory]: ../panacea/test/fixtures

--- a/panacea/README.md
+++ b/panacea/README.md
@@ -129,3 +129,12 @@ All error responses take have the following format:
   }
 }
 ```
+
+### `/api/ast`
+
+|             |                                                                          |
+|-------------|------------------------------------------------------------------------- |
+| Description | Convert an PML AST into a PML Document                                   |
+| Methods     | `POST`                                                                   |
+| Parameters  | An object containing the *pml ast* to be converted                       |
+| Returns     | The PML document as an attachment named `pml-tx.pml`, or an error object |

--- a/panacea/README.md
+++ b/panacea/README.md
@@ -36,7 +36,8 @@ Tokens can be generated using: `Panacea.AccessToken.generate()`
       "label": "cocaine",
       "line": 2
     }
-  ]
+  ],
+  "ast": "AST representation of the provided PML file - base64 encoded"
 }
 ```
 

--- a/panacea/README.md
+++ b/panacea/README.md
@@ -8,7 +8,10 @@ Chiron to provide DDI analysis, these must be running for Panacea to work.
 Api Endpoints
 -------------
 
-All API endpoints require the *Authorization* header to contain a valid token.
+All API endpoints require a valid *authorization token* to be provided. The
+*token* can be sent in the *Authorization* header or as the
+*authorization_token* query parameter.
+
 Tokens can be generated using: `Panacea.AccessToken.generate()`
 
 ### `/api/pml`

--- a/panacea/lib/panacea/pml/analysis.ex
+++ b/panacea/lib/panacea/pml/analysis.ex
@@ -8,6 +8,11 @@ defmodule Panacea.Pml.Analysis do
     drugs = Drugs.run(ast)
     unnamed = Unnamed.run(ast)
 
-    {:ok, %Analysis{drugs: drugs, unnamed: unnamed, ast: ast}}
+    encoded_ast =
+      ast
+      |> :erlang.term_to_binary()
+      |> Base.encode64()
+
+    {:ok, %Analysis{drugs: drugs, unnamed: unnamed, ast: encoded_ast}}
   end
 end

--- a/panacea/lib/panacea/pml/analysis.ex
+++ b/panacea/lib/panacea/pml/analysis.ex
@@ -1,10 +1,17 @@
 defmodule Panacea.Pml.Analysis do
   alias __MODULE__
 
-  defstruct drugs: []
+  defstruct [:drugs, :ast]
+
+  def new(ast) do
+    %Analysis{
+      drugs: [],
+      ast: ast
+    }
+  end
 
   def run(ast) do
-    {:ok, analyse(%Analysis{}, ast)}
+    {:ok, analyse(Analysis.new(ast), ast)}
   end
 
   defp analyse(result, {:drug, [line: line], label}) do

--- a/panacea/test/controllers/ast_controller_test.exs
+++ b/panacea/test/controllers/ast_controller_test.exs
@@ -1,0 +1,57 @@
+defmodule Panacea.AstControllerTest do
+  use Panacea.AuthorizedConnCase
+
+  describe "AstController.to_pml/2" do
+    test "raises an error when no ast is provided", %{conn: conn} do
+      assert_raise Phoenix.ActionClauseError, fn ->
+        post conn, ast_path(conn, :to_pml)
+      end
+    end
+
+    test "returns an error for non base64 encoded asts", %{conn: conn} do
+      conn = post conn, ast_path(conn, :to_pml), %{ast: "foo"}
+
+      assert conn.status == 422
+
+      error = response_body(conn) |> Map.get("error")
+      assert error["title"]=~ "Encoding error"
+    end
+
+    test "turns the provided ast into pml", %{conn: conn} do
+      pml = """
+      process foo {
+        task bar {
+          action baz {
+            tool { "pills" }
+            script { "eat the pills" }
+            agent { "patient" }
+            requires { drug { "torasemide" } }
+            provides { "a cured patient" }
+          }
+          action baz2 {
+            tool { "pills" }
+            script { "eat the pills" }
+            agent { (intangible) (inscrutable) pml.wtf && ("foo" || 1 != 2) }
+            requires { drug { "trandolapril" } }
+            provides { "a cured patient" }
+          }
+        }
+      }
+      """
+      |> String.replace_trailing("\n", "")
+
+      {:ok, ast} = Panacea.Pml.Parser.parse(pml)
+
+      encoded_ast =
+        ast
+        |> :erlang.term_to_binary()
+        |> Base.encode64()
+
+      conn = post conn, ast_path(conn, :to_pml), %{ast: encoded_ast}
+
+      assert conn.status == 200
+      assert conn |> get_resp_header("content-disposition") == [~s(attachment; filename="pml-tx.pml")]
+      assert conn.resp_body == pml
+    end
+  end
+end

--- a/panacea/test/controllers/ast_controller_test.exs
+++ b/panacea/test/controllers/ast_controller_test.exs
@@ -50,7 +50,6 @@ defmodule Panacea.AstControllerTest do
       conn = post conn, ast_path(conn, :to_pml), %{ast: encoded_ast}
 
       assert conn.status == 200
-      assert conn |> get_resp_header("content-disposition") == [~s(attachment; filename="pml-tx.pml")]
       assert conn.resp_body == pml
     end
   end

--- a/panacea/test/controllers/ast_controller_test.exs
+++ b/panacea/test/controllers/ast_controller_test.exs
@@ -4,12 +4,12 @@ defmodule Panacea.AstControllerTest do
   describe "AstController.to_pml/2" do
     test "raises an error when no ast is provided", %{conn: conn} do
       assert_raise Phoenix.ActionClauseError, fn ->
-        post conn, ast_path(conn, :to_pml)
+        get conn, ast_path(conn, :to_pml)
       end
     end
 
     test "returns an error for non base64 encoded asts", %{conn: conn} do
-      conn = post conn, ast_path(conn, :to_pml), %{ast: "foo"}
+      conn = get conn, ast_path(conn, :to_pml), %{ast: "foo"}
 
       assert conn.status == 422
 
@@ -47,10 +47,13 @@ defmodule Panacea.AstControllerTest do
         |> :erlang.term_to_binary()
         |> Base.encode64()
 
-      conn = post conn, ast_path(conn, :to_pml), %{ast: encoded_ast}
+      conn = get conn, ast_path(conn, :to_pml), %{ast: encoded_ast}
 
       assert conn.status == 200
       assert conn.resp_body == pml
+
+      [disposition] = conn |> get_resp_header("content-disposition")
+      assert disposition =~ "attachment;"
     end
   end
 end

--- a/panacea/test/controllers/pml_controller_test.exs
+++ b/panacea/test/controllers/pml_controller_test.exs
@@ -55,5 +55,29 @@ defmodule Panacea.PmlControllerTest do
         %{"label" => "paracetamol", "line" => 8}
       ]
     end
+
+    test "returns the AST representation of the pml", %{conn: conn} do
+      filename = "no_ddis.pml"
+      file_path = Path.join(@fixtures_dir, filename)
+      upload = %Plug.Upload{path: file_path, filename: filename}
+
+      conn = post conn, pml_path(conn, :upload), %{upload: %{file: upload}}
+
+      assert conn.status == 200
+
+      {:ok, ast} =
+        file_path
+        |> File.read!()
+        |> Panacea.Pml.Parser.parse()
+
+      received_ast =
+        conn
+        |> response_body()
+        |> Map.get("ast")
+        |> Base.decode64!()
+        |> :erlang.binary_to_term()
+
+      assert received_ast == ast
+    end
   end
 end

--- a/panacea/test/plugs/require_access_token_test.exs
+++ b/panacea/test/plugs/require_access_token_test.exs
@@ -3,7 +3,7 @@ defmodule Panacea.Plugs.RequireAccessTokenTest do
   alias Panacea.Plugs.RequireAccessToken
 
   describe "call/2" do
-    test "forbids requests with no authorization header", %{conn: conn} do
+    test "forbids requests with no authorization token", %{conn: conn} do
       resp = RequireAccessToken.call(conn, [])
 
       assert resp.status == 403
@@ -21,7 +21,34 @@ defmodule Panacea.Plugs.RequireAccessTokenTest do
     test "permits requests with a valid authorization header", %{conn: conn} do
       authorized_conn =
         conn
-        |> put_req_header("authorization", Panacea.AccessToken.generate)
+        |> put_req_header("authorization", Panacea.AccessToken.generate())
+        |> RequireAccessToken.call([])
+
+      refute authorized_conn.halted
+    end
+
+    test "forbids requests with an invalid authorization token", %{conn: conn} do
+      resp =
+        %{conn| query_string: "authorization_token=foo"}
+        |> RequireAccessToken.call([])
+
+      assert resp.status == 403
+    end
+
+    test "permits requests with a valid url encoded authorization token", %{conn: conn} do
+      token = Panacea.AccessToken.generate()
+      authorized_conn =
+        %{conn| query_string: "authorization_token=#{token}"}
+        |> RequireAccessToken.call([])
+
+      refute authorized_conn.halted
+    end
+
+    test "when a token is provided in the headers and url, the url wins", %{conn: conn} do
+      token = Panacea.AccessToken.generate()
+      authorized_conn =
+        %{conn| query_string: "authorization_token=#{token}"}
+        |> put_req_header("authorization", "foo")
         |> RequireAccessToken.call([])
 
       refute authorized_conn.halted

--- a/panacea/web/controllers/ast_controller.ex
+++ b/panacea/web/controllers/ast_controller.ex
@@ -33,6 +33,7 @@ defmodule Panacea.AstController do
 
   defp respond({:ok, pml}, conn) do
     conn
+    |> put_resp_header("content-disposition", ~s[attachment; filename="pml-tx.pml"])
     |> send_resp(200, pml)
   end
   defp respond({:error, reason}, conn) do

--- a/panacea/web/controllers/ast_controller.ex
+++ b/panacea/web/controllers/ast_controller.ex
@@ -33,7 +33,6 @@ defmodule Panacea.AstController do
 
   defp respond({:ok, pml}, conn) do
     conn
-    |> put_resp_header("content-disposition", ~s(attachment; filename="pml-tx.pml"))
     |> send_resp(200, pml)
   end
   defp respond({:error, reason}, conn) do

--- a/panacea/web/controllers/ast_controller.ex
+++ b/panacea/web/controllers/ast_controller.ex
@@ -1,0 +1,42 @@
+defmodule Panacea.AstController do
+  use Panacea.Web, :controller
+
+  def to_pml(conn, %{"ast" => encoded_ast}) do encoded_ast
+    |> decode()
+    |> to_erlang_term()
+    |> to_pml()
+    |> respond(conn)
+  end
+
+  defp decode(encoded_ast) do
+    case Base.decode64(encoded_ast) do
+      {:ok, binary} ->
+        {:ok, binary}
+      :error ->
+        {:error, {:encoding_error, "AST is not base64 encoded."}}
+    end
+  end
+
+  defp to_erlang_term({:ok, binary}) do
+    {:ok, :erlang.binary_to_term(binary)}
+  end
+  defp to_erlang_term({:error, reason}) do
+    {:error, reason}
+  end
+
+  defp to_pml({:ok, ast}) do
+    {:ok, Panacea.Pml.Ast.to_pml(ast)}
+  end
+  defp to_pml({:error, reason}) do
+    {:error, reason}
+  end
+
+  defp respond({:ok, pml}, conn) do
+    conn
+    |> put_resp_header("content-disposition", ~s(attachment; filename="pml-tx.pml"))
+    |> send_resp(200, pml)
+  end
+  defp respond({:error, reason}, conn) do
+    Panacea.BaseController.respond({:error, reason}, conn)
+  end
+end

--- a/panacea/web/controllers/pml_controller.ex
+++ b/panacea/web/controllers/pml_controller.ex
@@ -25,6 +25,12 @@ defmodule Panacea.PmlController do
   defp analyse({:ok, ast}), do: Panacea.Pml.Analysis.run(ast)
   defp analyse({:error, reason}), do: {:error, reason}
 
-  defp to_result({:ok, analysis}),  do: {:ok, %{drugs: analysis.drugs}}
+  defp to_result({:ok, analysis}) do
+    ast =
+      analysis.ast
+      |> :erlang.term_to_binary()
+      |> Base.encode64()
+    {:ok, %{drugs: analysis.drugs, ast: ast}}
+  end
   defp to_result({:error, reason}), do: {:error, reason}
 end

--- a/panacea/web/controllers/pml_controller.ex
+++ b/panacea/web/controllers/pml_controller.ex
@@ -25,12 +25,6 @@ defmodule Panacea.PmlController do
   defp analyse({:ok, ast}), do: Panacea.Pml.Analysis.run(ast)
   defp analyse({:error, reason}), do: {:error, reason}
 
-  defp to_result({:ok, analysis}) do
-    ast =
-      analysis.ast
-      |> :erlang.term_to_binary()
-      |> Base.encode64()
-    {:ok, %{drugs: analysis.drugs, unnamed: analysis.unnamed, ast: ast}}
-  end
+  defp to_result({:ok, analysis}), do: {:ok, analysis}
   defp to_result({:error, reason}), do: {:error, reason}
 end

--- a/panacea/web/plugs/require_access_token.ex
+++ b/panacea/web/plugs/require_access_token.ex
@@ -5,20 +5,30 @@ defmodule Panacea.Plugs.RequireAccessToken do
 
   def call(conn, _opts) do
     conn
-    |> fetch_auth_header()
+    |> fetch_auth_token_from_headers()
+    |> fetch_query_params()
+    |> fetch_auth_token_from_url()
     |> verify_token()
   end
 
-  defp fetch_auth_header(conn) do
+  defp fetch_auth_token_from_headers(conn) do
     case get_req_header(conn, "authorization") do
       [] ->
         conn
-        |> send_resp(:forbidden, "access token missing")
-        |> halt()
 
       [token] ->
         conn
         |> assign(:access_token, token)
+    end
+  end
+
+  defp fetch_auth_token_from_url(conn) do
+    case conn.params do
+      %{"authorization_token" => token} ->
+        conn
+        |> assign(:access_token, token)
+      _ ->
+        conn
     end
   end
 

--- a/panacea/web/router.ex
+++ b/panacea/web/router.ex
@@ -26,5 +26,6 @@ defmodule Panacea.Router do
     post "/pml", PmlController, :upload
     post "/uris", AsclepiusController, :uris_for_labels
     post "/ddis", AsclepiusController, :ddis
+    post "/ast", AstController, :to_pml
   end
 end

--- a/panacea/web/router.ex
+++ b/panacea/web/router.ex
@@ -26,6 +26,6 @@ defmodule Panacea.Router do
     post "/pml", PmlController, :upload
     post "/uris", AsclepiusController, :uris_for_labels
     post "/ddis", AsclepiusController, :ddis
-    post "/ast", AstController, :to_pml
+    get  "/ast", AstController, :to_pml
   end
 end

--- a/panacea/web/static/css/app.css
+++ b/panacea/web/static/css/app.css
@@ -34,3 +34,7 @@
   height: 128px;
   margin: 40px;
 }
+
+.padded-bottom {
+  padding-bottom: 20px;
+}

--- a/panacea/web/static/js/app.js
+++ b/panacea/web/static/js/app.js
@@ -48,17 +48,11 @@ async function handleDrugsResponse(response) {
   });
 }
 
-async function prepareDownloadButton(ast) {
-  try {
-    const pmlDownloadAnchor = document.getElementById('pml-download-anchor');
-    const response = await Request.pml(ast);
-    const pml = await response.text();
-    pmlDownloadAnchor.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(ast));
-    pmlDownloadAnchor.setAttribute('download', 'pml-tx.pml');
-  } catch (e) {
-    View.displayNetworkError(e);
-  }
-}
+const prepareDownloadButton = ast => {
+  const pmlDownloadAnchor = document.getElementById('pml-download-anchor');
+  const href = `/api/ast?ast=${encodeURIComponent(ast)}&authorization_token=${encodeURIComponent(Request.apiAccessToken)}`;
+  pmlDownloadAnchor.setAttribute('href', href);
+};
 
 async function handleUrisResponse(response, ast) {
   await handleResponse(response, async function ({uris: {found, not_found: unidentifiedDrugs}}) {

--- a/panacea/web/static/js/app.js
+++ b/panacea/web/static/js/app.js
@@ -48,12 +48,6 @@ async function handleDrugsResponse(response) {
   });
 }
 
-const prepareDownloadButton = ast => {
-  const pmlDownloadAnchor = document.getElementById('pml-download-anchor');
-  const href = `/api/ast?ast=${encodeURIComponent(ast)}&authorization_token=${encodeURIComponent(Request.apiAccessToken)}`;
-  pmlDownloadAnchor.setAttribute('href', href);
-};
-
 async function handleUrisResponse(response, ast) {
   await handleResponse(response, async function ({uris: {found, not_found: unidentifiedDrugs}}) {
     const uris = found.map(x => x.uri);
@@ -63,8 +57,7 @@ async function handleUrisResponse(response, ast) {
       return acc;
     }, {});
 
-    prepareDownloadButton(ast);
-    View.displayDownloadButton();
+    View.preparePMLDownloadButton(Request.generatePMLHref(ast));
 
     if (labels.length > 0) {
       View.displayDrugs(labels);

--- a/panacea/web/static/js/app.js
+++ b/panacea/web/static/js/app.js
@@ -48,28 +48,17 @@ async function handleDrugsResponse(response) {
   });
 }
 
-const triggerDownload = (fileName, fileContents) => {
-  const element = document.createElement('a');
-  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(fileContents));
-  element.setAttribute('download', fileName);
-  element.style.display = 'none';
-  document.body.appendChild(element);
-  element.click();
-  document.body.removeChild(element);
-};
-
-const prepareDownloadButton = ast => {
-  const pmlDownloadButton = document.getElementById('pml-download-button');
-  pmlDownloadButton.onclick = async function(){
-    try {
-      const response = await Request.pml(ast);
-      const pml = await response.text();
-      triggerDownload('pml-tx.pml', pml);
-    } catch (e) {
-      View.displayNetworkError(e);
-    }
+async function prepareDownloadButton(ast) {
+  try {
+    const pmlDownloadAnchor = document.getElementById('pml-download-anchor');
+    const response = await Request.pml(ast);
+    const pml = await response.text();
+    pmlDownloadAnchor.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(ast));
+    pmlDownloadAnchor.setAttribute('download', 'pml-tx.pml');
+  } catch (e) {
+    View.displayNetworkError(e);
   }
-};
+}
 
 async function handleUrisResponse(response, ast) {
   await handleResponse(response, async function ({uris: {found, not_found: unidentifiedDrugs}}) {

--- a/panacea/web/static/js/request.js
+++ b/panacea/web/static/js/request.js
@@ -25,3 +25,10 @@ export const uris = labels => {
 export const ddis = drugs => {
   return post('/api/ddis', JSON.stringify({drugs}), defaultHeaders);
 };
+
+export const generatePMLHref = ast => {
+  const endpoint = '/api/ast';
+  const astParam = `ast=${encodeURIComponent(ast)}`;
+  const tokenParam = `authorization_token=${encodeURIComponent(apiAccessToken)}`;
+  return `${endpoint}?${astParam}&${tokenParam}`;
+};

--- a/panacea/web/static/js/request.js
+++ b/panacea/web/static/js/request.js
@@ -18,6 +18,10 @@ export const drugs = formData => {
   return post('/api/pml', formData, formHeaders);
 };
 
+export const pml = ast => {
+  return post('/api/ast', JSON.stringify({ast}), defaultHeaders);
+};
+
 export const uris = labels => {
   return post('/api/uris', JSON.stringify({labels}), defaultHeaders);
 };

--- a/panacea/web/static/js/request.js
+++ b/panacea/web/static/js/request.js
@@ -1,4 +1,4 @@
-const apiAccessToken = document.getElementById('api-access-token').content;
+export const apiAccessToken = document.getElementById('api-access-token').content;
 const formHeaders = new Headers({authorization: apiAccessToken});
 const defaultHeaders = new Headers({
   "Authorization": apiAccessToken,
@@ -16,10 +16,6 @@ async function post(endpoint, body, headers) {
 
 export const drugs = formData => {
   return post('/api/pml', formData, formHeaders);
-};
-
-export const pml = ast => {
-  return post('/api/ast', JSON.stringify({ast}), defaultHeaders);
 };
 
 export const uris = labels => {

--- a/panacea/web/static/js/request.js
+++ b/panacea/web/static/js/request.js
@@ -1,4 +1,4 @@
-export const apiAccessToken = document.getElementById('api-access-token').content;
+const apiAccessToken = document.getElementById('api-access-token').content;
 const formHeaders = new Headers({authorization: apiAccessToken});
 const defaultHeaders = new Headers({
   "Authorization": apiAccessToken,

--- a/panacea/web/static/js/view.js
+++ b/panacea/web/static/js/view.js
@@ -3,6 +3,7 @@ const unidentifiedDrugsPanel = document.getElementById('unidentified-drugs-panel
 const ddisPanel = document.getElementById('ddis-panel');
 const errorPanel = document.getElementById('error-panel');
 const pmlDownloadContainer = document.getElementById('pml-download-container');
+const pmlDownloadAnchor = document.getElementById('pml-download-anchor');
 
 const hideElement = element => {
   element.classList.add('hidden');
@@ -28,8 +29,13 @@ export const displayDrugs = drugs => {
   showElement(drugsPanel);
 };
 
-export const displayDownloadButton = () => {
+const displayDownloadButton = () => {
   showElement(pmlDownloadContainer);
+};
+
+export const preparePMLDownloadButton = href => {
+  pmlDownloadAnchor.setAttribute('href', href);
+  displayDownloadButton();
 };
 
 const hideDownloadButton = () => {

--- a/panacea/web/static/js/view.js
+++ b/panacea/web/static/js/view.js
@@ -2,6 +2,7 @@ const drugsPanel = document.getElementById('drugs-panel');
 const unidentifiedDrugsPanel = document.getElementById('unidentified-drugs-panel');
 const ddisPanel = document.getElementById('ddis-panel');
 const errorPanel = document.getElementById('error-panel');
+const pmlDownloadContainer = document.getElementById('pml-download-container');
 
 const hideElement = element => {
   element.classList.add('hidden');
@@ -25,6 +26,14 @@ export const displayDrugs = drugs => {
   drugsTextElement.innerHTML = `<p>${preamble}</p><ul>${drugsHTML}</ul>`;
 
   showElement(drugsPanel);
+};
+
+export const displayDownloadButton = () => {
+  showElement(pmlDownloadContainer);
+};
+
+const hideDownloadButton = () => {
+  hideElement(pmlDownloadContainer);
 };
 
 export const displayUnidentifiedDrugs = drugs => {
@@ -99,4 +108,5 @@ const fileInputElement = document.getElementById('file-input');
 fileInputElement.addEventListener('change', function(e) {
   filenameDisplayElement.value = this.files[0].name;
   hideResults();
+  hideDownloadButton();
 });

--- a/panacea/web/templates/page/index.html.eex
+++ b/panacea/web/templates/page/index.html.eex
@@ -24,7 +24,7 @@
 
 <div class="center hidden padded-bottom fades-in" id="pml-download-container">
   <a id="pml-download-anchor">
-    <button type="button" class="btn btn-default btn-lg" id="pml-download-button">
+    <button type="button" class="btn btn-default btn-lg">
       <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
       Download PML TX File
     </button>

--- a/panacea/web/templates/page/index.html.eex
+++ b/panacea/web/templates/page/index.html.eex
@@ -22,11 +22,13 @@
   <div class="panel-body" id="drugs-text"></div>
 </div>
 
-<div class="center hidden padded-bottom" id="pml-download-container">
-  <button type="button" class="btn btn-default btn-lg" id="pml-download-button">
-    <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
-    Download PML TX File
-  </button>
+<div class="center hidden padded-bottom fades-in" id="pml-download-container">
+  <a id="pml-download-anchor">
+    <button type="button" class="btn btn-default btn-lg" id="pml-download-button">
+      <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
+      Download PML TX File
+    </button>
+  </a>
 </div>
 
 <div class="panel panel-warning hidden fades-in" id="unidentified-drugs-panel">

--- a/panacea/web/templates/page/index.html.eex
+++ b/panacea/web/templates/page/index.html.eex
@@ -23,11 +23,9 @@
 </div>
 
 <div class="center hidden padded-bottom fades-in" id="pml-download-container">
-  <a id="pml-download-anchor">
-    <button type="button" class="btn btn-default btn-lg">
-      <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
-      Download PML TX File
-    </button>
+  <a id="pml-download-anchor" class="btn btn-default btn-lg">
+    <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
+    Download PML TX File
   </a>
 </div>
 

--- a/panacea/web/templates/page/index.html.eex
+++ b/panacea/web/templates/page/index.html.eex
@@ -21,6 +21,14 @@
   <div class="panel-heading">Drugs Found</div>
   <div class="panel-body" id="drugs-text"></div>
 </div>
+
+<div class="center hidden padded-bottom" id="pml-download-container">
+  <button type="button" class="btn btn-default btn-lg" id="pml-download-button">
+    <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
+    Download PML TX File
+  </button>
+</div>
+
 <div class="panel panel-warning hidden fades-in" id="unidentified-drugs-panel">
   <div class="panel-heading">Unidentified Drugs Found</div>
   <div class="panel-body" id="unidentified-drugs-text"></div>


### PR DESCRIPTION
* `/api/pml` returns the AST as part of the repsonse - see readme

* `/api/ast` takes an AST and returns the corresponding PML as an attachment