### PR TITLE
removes case from `analyse/2`

### DIFF
--- a/panacea/lib/panacea/pml/analysis/drugs.ex
+++ b/panacea/lib/panacea/pml/analysis/drugs.ex
@@ -4,16 +4,13 @@ defmodule Panacea.Pml.Analysis.Drugs do
     analyse([], ast)
   end
 
-  defp analyse(result, {:drug, [line: line], label}) do
+  defp analyse(result, {:requires, _, {:drug, [line: line], label}}) do
     [%{label: strip_quotes(label), line: line} | result]
   end
   defp analyse(result, {_, _, children}) when is_list(children) do
     Enum.reduce(children, result, fn(child, acc) ->
       analyse(acc, child)
     end)
-  end
-  defp analyse(result, {_, _, child}) do
-    analyse(result, child)
   end
   defp analyse(result, _), do: result
 

--- a/panacea/lib/panacea/pml/analysis/unnamed.ex
+++ b/panacea/lib/panacea/pml/analysis/unnamed.ex
@@ -18,9 +18,5 @@ defmodule Panacea.Pml.Analysis.Unnamed do
       analyse(acc, child)
     end)
   end
-  defp analyse(result, {_, _, child}) do
-    analyse(result, child)
-  end
   defp analyse(result, _), do: result
-
 end


### PR DESCRIPTION
```elixir
  defp analyse(result, {_, _, child}) do
    analyse(result, child)
  end
```

The case above matches leaf nodes in the AST - `script`, `tool`,
`agent`, `expression` etc.

The only leaf node we want to analyse is `{:requires, _, {:drug ...}}` -
which we can explicitly pattern match for.

With this pattern match in place, the case can be safely removed.