### PR TITLE
initial attempt at DDI categorization

### DIFF
--- a/panacea/README.md
+++ b/panacea/README.md
@@ -104,21 +104,28 @@ Tokens can be generated using: `Panacea.AccessToken.generate()`
 
 ### `/api/ddis`
 
-|              |                                                                                                  |
-|--------------|--------------------------------------------------------------------------------------------------|
-| Description  | Find all drug-drug interactions (DDI) in the DINTO ontology which involve only the *given* drugs |
-| Methods      | `POST`                                                                                           |
-| Request Body | An object containing a list of *DINTO URIs*                                                      |
-| Returns      | Response detailed below, or an error object                                                      |
+|              |                                                                                                                                     |
+|--------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| Description  | Find all drug-drug interactions (DDI) in the DINTO ontology which involve only the *given* drugs, in the context of the given *AST* |
+| Methods      | `POST`                                                                                                                              |
+| Request Body | An object containing a list of *drugs* and an *AST*                                                                                 |
+| Returns      | Response detailed below, or an error object                                                                                         |
 
 #### Example
 ##### Request Body
 ```json
 {
   "drugs": [
-    "http://purl.obolibrary.org/obo/DINTO_DB00214",
-    "http://purl.obolibrary.org/obo/DINTO_DB00519"
-  ]
+    {
+      "uri": "http://purl.obolibrary.org/obo/DINTO_DB00214",
+      "label": "torasemide"
+    },
+    {
+      "uri": "http://purl.obolibrary.org/obo/DINTO_DB00519",
+      "label": "trandolapril"
+    }
+  ],
+  "ast": "encoded AST returned from /api/pml"
 }
 ```
 
@@ -133,7 +140,12 @@ Tokens can be generated using: `Panacea.AccessToken.generate()`
       "label": "torasemide/trandolapril DDI",
       "uri": "http://purl.obolibrary.org/obo/DINTO_11031",
       "harmful": false,
-      "spacing": 3
+      "spacing": 3,
+      "category": "sequential",
+      "enclosing_construct": {
+        "type": "sequence",
+        "line": 6
+      }
     }
   ]
 }

--- a/panacea/README.md
+++ b/panacea/README.md
@@ -142,10 +142,12 @@ Tokens can be generated using: `Panacea.AccessToken.generate()`
       "harmful": false,
       "spacing": 3,
       "category": "sequential",
-      "enclosing_construct": {
-        "type": "sequence",
-        "line": 6
-      }
+      "enclosing_constructs": [
+        {
+          "type": "sequence",
+          "line": 6
+        }
+      ]
     }
   ]
 }

--- a/panacea/config/config.exs
+++ b/panacea/config/config.exs
@@ -22,6 +22,8 @@ config :panacea, :asclepius,
   uri: URI.parse("http://localhost:5000"),
   api: Panacea.Asclepius.Remote.HTTP
 
+config :panacea, :composite_pml_constructs, [:task, :sequence, :branch, :selection, :iteration, :action, :process]
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/panacea/lib/panacea/pml/analysis/clashes.ex
+++ b/panacea/lib/panacea/pml/analysis/clashes.ex
@@ -1,5 +1,5 @@
 defmodule Panacea.Pml.Analysis.Clashes do
-  @composite [:task, :sequence, :branch, :selection, :iteration, :action, :process]
+  @composite_constructs Application.get_env(:panacea, :composite_pml_constructs)
 
   def run(ast) do
     analyse(%{}, ast)
@@ -11,7 +11,7 @@ defmodule Panacea.Pml.Analysis.Clashes do
     end)
   end
 
-  defp analyse(result, {type, attrs, children}) when type in @composite do
+  defp analyse(result, {type, attrs, children}) when type in @composite_constructs do
     result =
       case Keyword.get(attrs, :name) do
         nil ->

--- a/panacea/lib/panacea/pml/analysis/ddis.ex
+++ b/panacea/lib/panacea/pml/analysis/ddis.ex
@@ -46,8 +46,11 @@ defmodule Panacea.Pml.Analysis.Ddis do
   end
   defp analyse_ancestors({:selection, line, inner_id}, ancestors) do
     inner = %{"type" => :selection, "line" => line}
+    sorted_ancestors = Enum.sort(ancestors, fn({_,_,id_a},{_,_,id_b}) ->
+      id_a >= id_b
+    end)
 
-    case Enum.find(ancestors, fn {type, _, id} -> type == :iteration && id < inner_id end) do
+    case Enum.find(sorted_ancestors, fn {type, _, id} -> type == :iteration && id < inner_id end) do
       nil ->
         {:alternative, [inner]}
       {:iteration, line, _} ->

--- a/panacea/lib/panacea/pml/analysis/ddis.ex
+++ b/panacea/lib/panacea/pml/analysis/ddis.ex
@@ -1,5 +1,6 @@
 defmodule Panacea.Pml.Analysis.Ddis do
-  @composite [:task, :sequence, :branch, :selection, :iteration, :action, :process]
+  alias Panacea.Pml.Analysis.Util
+  @composite_constructs Application.get_env(:panacea, :composite_pml_constructs)
 
   def run(_, [], _), do: []
   def run(ast, ddis, drugs) do
@@ -41,7 +42,7 @@ defmodule Panacea.Pml.Analysis.Ddis do
 
   def build_ancestries(ast), do: do_build_ancestries(ast, [], %{})
 
-  defp do_build_ancestries({type, attrs, children}, ancestors, acc) when type in @composite do
+  defp do_build_ancestries({type, attrs, children}, ancestors, acc) when type in @composite_constructs do
     line =  Keyword.get(attrs, :line)
     # TODO: add some unique ID to each element, in case there
     #       are constructs with children on the same line
@@ -51,13 +52,6 @@ defmodule Panacea.Pml.Analysis.Ddis do
     end)
   end
   defp do_build_ancestries({:requires, _, {:drug, _, label}}, ancestors, acc) do
-    Map.put(acc, strip_quotes(label), ancestors)
-  end
-
-  # TODO: move this to a shared module - copy pasted it from Analysis.Drugs for now
-  defp strip_quotes(char_list) do
-    char_list
-    |> :string.strip(:both, ?")
-    |> to_string()
+    Map.put(acc, Util.strip_quotes(label), ancestors)
   end
 end

--- a/panacea/lib/panacea/pml/analysis/ddis.ex
+++ b/panacea/lib/panacea/pml/analysis/ddis.ex
@@ -10,13 +10,13 @@ defmodule Panacea.Pml.Analysis.Ddis do
   end
 
   defp categorize_ddis(ancestries, ddis, drugs) do
-    uris_to_labels = Enum.into(drugs, %{}, fn %{uri: uri, label: label} ->
+    uris_to_labels = Enum.into(drugs, %{}, fn %{"uri" => uri, "label" => label} ->
       {uri, label}
     end)
 
     Enum.map(ddis, fn ddi ->
-      drug_a = uris_to_labels[ddi.drug_a]
-      drug_b = uris_to_labels[ddi.drug_b]
+      drug_a = uris_to_labels[ddi["drug_a"]]
+      drug_b = uris_to_labels[ddi["drug_b"]]
 
       ancestors_a = Map.get(ancestries, drug_a, []) |> MapSet.new()
       ancestors_b = Map.get(ancestries, drug_b, []) |> MapSet.new()
@@ -31,8 +31,8 @@ defmodule Panacea.Pml.Analysis.Ddis do
        |> Enum.max_by(fn {_, _, id} -> id end)
 
      ddi
-     |> Map.put(:category, category_for_construct(construct_type))
-     |> Map.put(:enclosing_construct, %{type: construct_type, line: line})
+     |> Map.put("category", category_for_construct(construct_type))
+     |> Map.put("enclosing_construct", %{"type" => construct_type, "line" => line})
   end
 
   defp category_for_construct(:branch),    do: :parallel
@@ -52,4 +52,5 @@ defmodule Panacea.Pml.Analysis.Ddis do
   defp do_build_ancestries({:requires, _, {:drug, _, label}}, ancestors, acc) do
     Map.put(acc, Util.strip_quotes(label), ancestors)
   end
+  defp do_build_ancestries(_, _, acc), do: acc
 end

--- a/panacea/lib/panacea/pml/analysis/ddis.ex
+++ b/panacea/lib/panacea/pml/analysis/ddis.ex
@@ -1,0 +1,63 @@
+defmodule Panacea.Pml.Analysis.Ddis do
+  @composite [:task, :sequence, :branch, :selection, :iteration, :action, :process]
+
+  def run(_, [], _), do: []
+  def run(ast, ddis, drugs) do
+    ast
+    |> build_ancestries()
+    |> categorize_ddis(ddis, drugs)
+  end
+
+  defp categorize_ddis(ancestries, ddis, drugs) do
+    uris_to_labels = Enum.into(drugs, %{}, fn %{uri: uri, label: label} ->
+      {uri, label}
+    end)
+
+    Enum.map(ddis, fn ddi ->
+      drug_a = uris_to_labels[ddi.drug_a]
+      drug_b = uris_to_labels[ddi.drug_b]
+
+      ancestors_a = Map.get(ancestries, drug_a, []) |> MapSet.new()
+      ancestors_b = Map.get(ancestries, drug_b, []) |> MapSet.new()
+
+      Map.put(ddi, :type, categorize_ddi(ancestors_a, ancestors_b))
+    end)
+  end
+
+  defp categorize_ddi(ancestors_a, ancestors_b) do
+     closest_common_ancestor =
+       MapSet.intersection(ancestors_a, ancestors_b)
+       |> Enum.max_by(fn {_, line} -> line end)
+
+     case closest_common_ancestor do
+       {:branch, _} ->
+         :parallel
+       {:selection, _} ->
+         :alternative
+       _ ->
+         :sequential
+     end
+  end
+
+  def build_ancestries(ast), do: do_build_ancestries(ast, [], %{})
+
+  defp do_build_ancestries({type, attrs, children}, ancestors, acc) when type in @composite do
+    line =  Keyword.get(attrs, :line)
+    # TODO: add some unique ID to each element, in case there
+    #       are constructs with children on the same line
+    new_ancestors = [{type, line}|ancestors]
+    Enum.reduce(children, acc, fn (child, a) ->
+      do_build_ancestries(child, new_ancestors, a)
+    end)
+  end
+  defp do_build_ancestries({:requires, _, {:drug, _, label}}, ancestors, acc) do
+    Map.put(acc, strip_quotes(label), ancestors)
+  end
+
+  # TODO: move this to a shared module - copy pasted it from Analysis.Drugs for now
+  defp strip_quotes(char_list) do
+    char_list
+    |> :string.strip(:both, ?")
+    |> to_string()
+  end
+end

--- a/panacea/lib/panacea/pml/analysis/drugs.ex
+++ b/panacea/lib/panacea/pml/analysis/drugs.ex
@@ -1,11 +1,12 @@
 defmodule Panacea.Pml.Analysis.Drugs do
+  alias Panacea.Pml.Analysis.Util
 
   def run(ast) do
     analyse([], ast)
   end
 
   defp analyse(result, {:requires, _, {:drug, [line: line], label}}) do
-    [%{label: strip_quotes(label), line: line} | result]
+    [%{label: Util.strip_quotes(label), line: line} | result]
   end
   defp analyse(result, {_, _, children}) when is_list(children) do
     Enum.reduce(children, result, fn(child, acc) ->
@@ -13,10 +14,4 @@ defmodule Panacea.Pml.Analysis.Drugs do
     end)
   end
   defp analyse(result, _), do: result
-
-  defp strip_quotes(char_list) do
-    char_list
-    |> :string.strip(:both, ?")
-    |> to_string()
-  end
 end

--- a/panacea/lib/panacea/pml/analysis/unnamed.ex
+++ b/panacea/lib/panacea/pml/analysis/unnamed.ex
@@ -1,12 +1,11 @@
 defmodule Panacea.Pml.Analysis.Unnamed do
-
-  @composite [:task, :sequence, :branch, :selection, :iteration, :action, :process]
+  @composite_constructs Application.get_env(:panacea, :composite_pml_constructs)
 
   def run(ast) do
     analyse([], ast)
   end
 
-  defp analyse(result, {type, attrs, children}) when type in @composite do
+  defp analyse(result, {type, attrs, children}) when type in @composite_constructs do
     result =
       if !Keyword.has_key?(attrs, :name) do
         [%{type: type, line: Keyword.get(attrs, :line)} | result]

--- a/panacea/lib/panacea/pml/analysis/util.ex
+++ b/panacea/lib/panacea/pml/analysis/util.ex
@@ -1,0 +1,7 @@
+defmodule Panacea.Pml.Analysis.Util do
+  def strip_quotes(char_list) do
+    char_list
+    |> :string.strip(:both, ?")
+    |> to_string()
+  end
+end

--- a/panacea/lib/panacea/pml/ast.ex
+++ b/panacea/lib/panacea/pml/ast.ex
@@ -9,6 +9,28 @@ defmodule Panacea.Pml.Ast do
     do_unquote(ast, 0)
   end
 
+  def decode(ast) do
+    ast
+    |> decode64()
+    |> to_erlang_term()
+  end
+
+  defp decode64(encoded_ast) do
+    case Base.decode64(encoded_ast) do
+      {:ok, binary} ->
+        {:ok, binary}
+      :error ->
+        {:error, {:encoding_error, "AST is not base64 encoded."}}
+    end
+  end
+
+  defp to_erlang_term({:ok, binary}) do
+    {:ok, :erlang.binary_to_term(binary)}
+  end
+  defp to_erlang_term({:error, reason}) do
+    {:error, reason}
+  end
+
   defp do_unquote({type, attrs, children}, depth) when type in @multi_line_constructs do
     optional_name = get_with_default(attrs, :name)
     optional_type = get_with_default(attrs, :type)

--- a/panacea/test/controllers/asclepius_controller_test.exs
+++ b/panacea/test/controllers/asclepius_controller_test.exs
@@ -108,10 +108,12 @@ defmodule Panacea.AsclepiusControllerTest do
             "drug_b" => "http://purl.obolibrary.org/obo/DINTO_DB00519",
             "label" => "torasemide/trandolapril DDI",
             "uri"   => "http://purl.obolibrary.org/obo/DINTO_11031",
-            "enclosing_construct" => %{
-              "type" => "process",
-              "line" => 1
-            }
+            "enclosing_constructs" => [
+              %{
+                "type" => "process",
+                "line" => 1
+              }
+            ]
           }
         ]
     end

--- a/panacea/test/panacea/pml/analysis/ddis_test.exs
+++ b/panacea/test/panacea/pml/analysis/ddis_test.exs
@@ -39,10 +39,12 @@ defmodule Panacea.Pml.Analysis.DdisTest do
           "category" => :sequential,
           "drug_a" => "http://purl.com/paracetamol",
           "drug_b" => "http://purl.com/cocaine",
-          "enclosing_construct" => %{
-            "type" => :process,
-            "line" => 1
-          }
+          "enclosing_constructs" => [
+            %{
+              "type" => :process,
+              "line" => 1
+            }
+          ]
         }
       ]
     end
@@ -67,10 +69,12 @@ defmodule Panacea.Pml.Analysis.DdisTest do
           "category" => :parallel,
           "drug_a" => "http://purl.com/paracetamol",
           "drug_b" => "http://purl.com/cocaine",
-          "enclosing_construct" => %{
-            "type" => :branch,
-            "line" => 2
-          }
+          "enclosing_constructs" => [
+            %{
+              "type" => :branch,
+              "line" => 2
+            }
+          ]
         }
       ]
     end
@@ -95,10 +99,48 @@ defmodule Panacea.Pml.Analysis.DdisTest do
           "category" => :alternative,
           "drug_a" => "http://purl.com/paracetamol",
           "drug_b" => "http://purl.com/cocaine",
-          "enclosing_construct" => %{
-            "type" => :selection,
-            "line" => 2
+          "enclosing_constructs" => [
+            %{
+              "type" => :selection,
+              "line" => 2
+            }
+          ]
+        }
+      ]
+    end
+
+    test "it categorizes repeated_alternative DDIs correctly" do
+      pml = """
+      process repeated_alternative_ddis {
+        iteration {
+          selection {
+            action s1 {
+              requires { drug { "paracetamol" } }
+            }
+            action s2 {
+              requires { drug { "cocaine" } }
+            }
           }
+        }
+      }
+      """
+      ast = parse_pml(pml)
+
+      assert Analysis.Ddis.run(ast, test_ddis(), test_drugs()) == [
+        %{
+          "category" => :repeated_alternative,
+          "drug_a" => "http://purl.com/paracetamol",
+          "drug_b" => "http://purl.com/cocaine",
+          "enclosing_constructs" => [
+            %{
+              "type" => :selection,
+              "line" => 3
+            },
+            %{
+              "type" => :iteration,
+              "line" => 2
+            }
+          ]
         }
       ]
     end
@@ -127,19 +169,23 @@ defmodule Panacea.Pml.Analysis.DdisTest do
           "category" => :alternative,
           "drug_a" => "http://purl.com/paracetamol",
           "drug_b" => "http://purl.com/cocaine",
-          "enclosing_construct" => %{
-            "type" => :selection,
-            "line" => 2
-          }
+          "enclosing_constructs" => [
+            %{
+              "type" => :selection,
+              "line" => 2
+            }
+          ]
         },
         %{
           "category" => :alternative,
           "drug_a" => "http://purl.com/paracetamol",
           "drug_b" => "http://purl.com/cocaine",
-          "enclosing_construct" => %{
-            "type" => :selection,
-            "line" => 2
-          }
+          "enclosing_constructs" => [
+            %{
+              "type" => :selection,
+              "line" => 2
+            }
+          ]
         }
       ]
     end
@@ -189,28 +235,34 @@ defmodule Panacea.Pml.Analysis.DdisTest do
           "category" => :alternative,
           "drug_a" => "http://purl.com/paracetamol",
           "drug_b" => "http://purl.com/cocaine",
-          "enclosing_construct" => %{
-            "type" => :selection,
-            "line" => 2
-          }
+          "enclosing_constructs" => [
+            %{
+              "type" => :selection,
+              "line" => 2
+            }
+          ]
         },
         %{
           "category" => :parallel,
           "drug_a" => "http://purl.com/cocaine",
           "drug_b" => "http://purl.com/flat_seven_up",
-          "enclosing_construct" => %{
-            "type" => :branch,
-            "line" => 6
-          }
+          "enclosing_constructs" => [
+            %{
+              "type" => :branch,
+              "line" => 6
+            }
+          ]
         },
         %{
           "category" => :sequential,
           "drug_a" => "http://purl.com/heroin",
           "drug_b" => "http://purl.com/skittles",
-          "enclosing_construct" => %{
-            "type" => :sequence,
-            "line" => 14
-          }
+          "enclosing_constructs" => [
+            %{
+              "type" => :sequence,
+              "line" => 14
+            }
+          ]
         }
       ]
     end

--- a/panacea/test/panacea/pml/analysis/ddis_test.exs
+++ b/panacea/test/panacea/pml/analysis/ddis_test.exs
@@ -21,7 +21,7 @@ defmodule Panacea.Pml.Analysis.DdisTest do
   end
 
   describe "run/2" do
-    test "it categorizes sequential DDIs correctly" do
+    test "it categorizes Sequential DDIs correctly" do
       pml = """
       process sequential_ddis {
         action s1 {
@@ -49,7 +49,7 @@ defmodule Panacea.Pml.Analysis.DdisTest do
       ]
     end
 
-    test "it categorizes parallel DDIs correctly" do
+    test "it categorizes Parallel DDIs correctly" do
       pml = """
       process parallel_ddis {
         branch {
@@ -79,9 +79,9 @@ defmodule Panacea.Pml.Analysis.DdisTest do
       ]
     end
 
-    test "it categorizes alternative DDIs correctly" do
+    test "it categorizes Alternative non-DDIs correctly" do
       pml = """
-      process alternative_ddis {
+      process alternative_non_ddis {
         selection {
           action s1 {
             requires { drug { "paracetamol" } }
@@ -109,7 +109,7 @@ defmodule Panacea.Pml.Analysis.DdisTest do
       ]
     end
 
-    test "it categorizes repeated_alternative DDIs correctly" do
+    test "it categorizes Repeated Alternative DDIs correctly" do
       pml = """
       process repeated_alternative_ddis {
         iteration {

--- a/panacea/test/panacea/pml/analysis/ddis_test.exs
+++ b/panacea/test/panacea/pml/analysis/ddis_test.exs
@@ -33,19 +33,6 @@ defmodule Panacea.Pml.Analysis.DdisTest do
     ast
   end
 
-  describe "build_ancestries/1" do
-    test "each drug points to all of its ancestors" do
-      ast = test_ast()
-      assert Analysis.Ddis.build_ancestries(ast) == %{
-        "paracetamol" => [action: 3, selection: 2, process: 1],
-        "flat seven up" => [action: 7, branch: 6, selection: 2, process: 1],
-        "cocaine" => [action: 10, branch: 6, selection: 2, process: 1],
-        "heroin" => [action: 15, sequence: 14, selection: 2, process: 1],
-        "skittles" => [action: 18, sequence: 14, selection: 2, process: 1]
-      }
-    end
-  end
-
   describe "run/2" do
     test "it categorizes the DDIs correctly" do
       ddis = [

--- a/panacea/test/panacea/pml/analysis/ddis_test.exs
+++ b/panacea/test/panacea/pml/analysis/ddis_test.exs
@@ -9,14 +9,14 @@ defmodule Panacea.Pml.Analysis.DdisTest do
 
   def test_ddis() do
     [
-      %{drug_a: "http://purl.com/paracetamol", drug_b: "http://purl.com/cocaine"}
+      %{"drug_a" => "http://purl.com/paracetamol", "drug_b" => "http://purl.com/cocaine"}
     ]
   end
 
   def test_drugs() do
     [
-      %{label: "paracetamol", uri: "http://purl.com/paracetamol"},
-      %{label: "cocaine", uri: "http://purl.com/cocaine"},
+      %{"label" => "paracetamol", "uri" => "http://purl.com/paracetamol"},
+      %{"label" => "cocaine", "uri" => "http://purl.com/cocaine"},
     ]
   end
 
@@ -36,12 +36,12 @@ defmodule Panacea.Pml.Analysis.DdisTest do
 
       assert Analysis.Ddis.run(ast, test_ddis(), test_drugs()) == [
         %{
-          category: :sequential,
-          drug_a: "http://purl.com/paracetamol",
-          drug_b: "http://purl.com/cocaine",
-          enclosing_construct: %{
-            type: :process,
-            line: 1
+          "category" => :sequential,
+          "drug_a" => "http://purl.com/paracetamol",
+          "drug_b" => "http://purl.com/cocaine",
+          "enclosing_construct" => %{
+            "type" => :process,
+            "line" => 1
           }
         }
       ]
@@ -64,12 +64,12 @@ defmodule Panacea.Pml.Analysis.DdisTest do
 
       assert Analysis.Ddis.run(ast, test_ddis(), test_drugs()) == [
         %{
-          category: :parallel,
-          drug_a: "http://purl.com/paracetamol",
-          drug_b: "http://purl.com/cocaine",
-          enclosing_construct: %{
-            type: :branch,
-            line: 2
+          "category" => :parallel,
+          "drug_a" => "http://purl.com/paracetamol",
+          "drug_b" => "http://purl.com/cocaine",
+          "enclosing_construct" => %{
+            "type" => :branch,
+            "line" => 2
           }
         }
       ]
@@ -92,12 +92,12 @@ defmodule Panacea.Pml.Analysis.DdisTest do
 
       assert Analysis.Ddis.run(ast, test_ddis(), test_drugs()) == [
         %{
-          category: :alternative,
-          drug_a: "http://purl.com/paracetamol",
-          drug_b: "http://purl.com/cocaine",
-          enclosing_construct: %{
-            type: :selection,
-            line: 2
+          "category" => :alternative,
+          "drug_a" => "http://purl.com/paracetamol",
+          "drug_b" => "http://purl.com/cocaine",
+          "enclosing_construct" => %{
+            "type" => :selection,
+            "line" => 2
           }
         }
       ]
@@ -130,45 +130,45 @@ defmodule Panacea.Pml.Analysis.DdisTest do
       }
       """
       ddis = [
-        %{drug_a: "http://purl.com/paracetamol", drug_b: "http://purl.com/cocaine"},
-        %{drug_a: "http://purl.com/cocaine", drug_b: "http://purl.com/flat_seven_up"},
-        %{drug_a: "http://purl.com/heroin", drug_b: "http://purl.com/skittles"}
+        %{"drug_a" => "http://purl.com/paracetamol", "drug_b" => "http://purl.com/cocaine"},
+        %{"drug_a" => "http://purl.com/cocaine", "drug_b" => "http://purl.com/flat_seven_up"},
+        %{"drug_a" => "http://purl.com/heroin", "drug_b" => "http://purl.com/skittles"}
       ]
       drugs = [
-        %{label: "paracetamol", uri: "http://purl.com/paracetamol"},
-        %{label: "cocaine", uri: "http://purl.com/cocaine"},
-        %{label: "flat seven up", uri: "http://purl.com/flat_seven_up"},
-        %{label: "heroin", uri: "http://purl.com/heroin"},
-        %{label: "skittles", uri: "http://purl.com/skittles"},
+        %{"label" => "paracetamol", "uri" => "http://purl.com/paracetamol"},
+        %{"label" => "cocaine", "uri" => "http://purl.com/cocaine"},
+        %{"label" => "flat seven up", "uri" => "http://purl.com/flat_seven_up"},
+        %{"label" => "heroin", "uri" => "http://purl.com/heroin"},
+        %{"label" => "skittles", "uri" => "http://purl.com/skittles"},
       ]
       ast = parse_pml(pml)
 
       assert Analysis.Ddis.run(ast, ddis, drugs) == [
         %{
-          category: :alternative,
-          drug_a: "http://purl.com/paracetamol",
-          drug_b: "http://purl.com/cocaine",
-          enclosing_construct: %{
-            type: :selection,
-            line: 2
+          "category" => :alternative,
+          "drug_a" => "http://purl.com/paracetamol",
+          "drug_b" => "http://purl.com/cocaine",
+          "enclosing_construct" => %{
+            "type" => :selection,
+            "line" => 2
           }
         },
         %{
-          category: :parallel,
-          drug_a: "http://purl.com/cocaine",
-          drug_b: "http://purl.com/flat_seven_up",
-          enclosing_construct: %{
-            type: :branch,
-            line: 6
+          "category" => :parallel,
+          "drug_a" => "http://purl.com/cocaine",
+          "drug_b" => "http://purl.com/flat_seven_up",
+          "enclosing_construct" => %{
+            "type" => :branch,
+            "line" => 6
           }
         },
         %{
-          category: :sequential,
-          drug_a: "http://purl.com/heroin",
-          drug_b: "http://purl.com/skittles",
-          enclosing_construct: %{
-            type: :sequence,
-            line: 14
+          "category" => :sequential,
+          "drug_a" => "http://purl.com/heroin",
+          "drug_b" => "http://purl.com/skittles",
+          "enclosing_construct" => %{
+            "type" => :sequence,
+            "line" => 14
           }
         }
       ]

--- a/panacea/test/panacea/pml/analysis/ddis_test.exs
+++ b/panacea/test/panacea/pml/analysis/ddis_test.exs
@@ -1,0 +1,72 @@
+defmodule Panacea.Pml.Analysis.DdisTest do
+  alias Panacea.Pml.Analysis
+  use ExUnit.Case
+
+  defp test_ast() do
+    pml = """
+    process proc {
+      selection {
+        action bar {
+          requires { drug { "paracetamol" } }
+        }
+        branch {
+          action baz {
+            requires { drug { "flat seven up" } }
+          }
+          action foo {
+            requires { drug { "cocaine" } }
+          }
+        }
+        sequence {
+           action s1 {
+             requires { drug { "heroin" } }
+           }
+           action s2 {
+             requires { drug { "skittles" }}
+           }
+        }
+      }
+    }
+    """
+
+    {:ok, ast} = Panacea.Pml.Parser.parse(pml)
+    ast
+  end
+
+  describe "build_ancestries/1" do
+    test "each drug points to all of its ancestors" do
+      ast = test_ast()
+      assert Analysis.Ddis.build_ancestries(ast) == %{
+        "paracetamol" => [action: 3, selection: 2, process: 1],
+        "flat seven up" => [action: 7, branch: 6, selection: 2, process: 1],
+        "cocaine" => [action: 10, branch: 6, selection: 2, process: 1],
+        "heroin" => [action: 15, sequence: 14, selection: 2, process: 1],
+        "skittles" => [action: 18, sequence: 14, selection: 2, process: 1]
+      }
+    end
+  end
+
+  describe "run/2" do
+    test "it categorizes the DDIs correctly" do
+      ddis = [
+        %{drug_a: "http://purl.com/paracetamol", drug_b: "http://purl.com/cocaine"},
+        %{drug_a: "http://purl.com/cocaine", drug_b: "http://purl.com/flat_seven_up"},
+        %{drug_a: "http://purl.com/heroin", drug_b: "http://purl.com/skittles"}
+      ]
+      drugs = [
+        %{label: "paracetamol", uri: "http://purl.com/paracetamol"},
+        %{label: "cocaine", uri: "http://purl.com/cocaine"},
+        %{label: "flat seven up", uri: "http://purl.com/flat_seven_up"},
+        %{label: "heroin", uri: "http://purl.com/heroin"},
+        %{label: "skittles", uri: "http://purl.com/skittles"},
+      ]
+      ast = test_ast()
+
+      assert Analysis.Ddis.run(ast, ddis, drugs) == [
+        %{type: :alternative, drug_a: "http://purl.com/paracetamol", drug_b: "http://purl.com/cocaine"},
+        %{type: :parallel, drug_a: "http://purl.com/cocaine", drug_b: "http://purl.com/flat_seven_up"},
+        %{type: :sequential, drug_a: "http://purl.com/heroin", drug_b: "http://purl.com/skittles"}
+      ]
+    end
+  end
+end

--- a/panacea/test/panacea/pml/analysis/ddis_test.exs
+++ b/panacea/test/panacea/pml/analysis/ddis_test.exs
@@ -2,39 +2,133 @@ defmodule Panacea.Pml.Analysis.DdisTest do
   alias Panacea.Pml.Analysis
   use ExUnit.Case
 
-  defp test_ast() do
-    pml = """
-    process proc {
-      selection {
-        action bar {
-          requires { drug { "paracetamol" } }
-        }
-        branch {
-          action baz {
-            requires { drug { "flat seven up" } }
-          }
-          action foo {
-            requires { drug { "cocaine" } }
-          }
-        }
-        sequence {
-           action s1 {
-             requires { drug { "heroin" } }
-           }
-           action s2 {
-             requires { drug { "skittles" }}
-           }
-        }
-      }
-    }
-    """
-
+  defp parse_pml(pml) do
     {:ok, ast} = Panacea.Pml.Parser.parse(pml)
     ast
   end
 
+  def test_ddis() do
+    [
+      %{drug_a: "http://purl.com/paracetamol", drug_b: "http://purl.com/cocaine"}
+    ]
+  end
+
+  def test_drugs() do
+    [
+      %{label: "paracetamol", uri: "http://purl.com/paracetamol"},
+      %{label: "cocaine", uri: "http://purl.com/cocaine"},
+    ]
+  end
+
   describe "run/2" do
-    test "it categorizes the DDIs correctly" do
+    test "it categorizes sequential DDIs correctly" do
+      pml = """
+      process sequential_ddis {
+        action s1 {
+          requires { drug { "paracetamol" } }
+        }
+        action s2 {
+          requires { drug { "cocaine" } }
+        }
+      }
+      """
+      ast = parse_pml(pml)
+
+      assert Analysis.Ddis.run(ast, test_ddis(), test_drugs()) == [
+        %{
+          category: :sequential,
+          drug_a: "http://purl.com/paracetamol",
+          drug_b: "http://purl.com/cocaine",
+          enclosing_construct: %{
+            type: :process,
+            line: 1
+          }
+        }
+      ]
+    end
+
+    test "it categorizes parallel DDIs correctly" do
+      pml = """
+      process parallel_ddis {
+        branch {
+          action b1 {
+            requires { drug { "paracetamol" } }
+          }
+          action b2 {
+            requires { drug { "cocaine" } }
+          }
+        }
+      }
+      """
+      ast = parse_pml(pml)
+
+      assert Analysis.Ddis.run(ast, test_ddis(), test_drugs()) == [
+        %{
+          category: :parallel,
+          drug_a: "http://purl.com/paracetamol",
+          drug_b: "http://purl.com/cocaine",
+          enclosing_construct: %{
+            type: :branch,
+            line: 2
+          }
+        }
+      ]
+    end
+
+    test "it categorizes alternative DDIs correctly" do
+      pml = """
+      process alternative_ddis {
+        selection {
+          action s1 {
+            requires { drug { "paracetamol" } }
+          }
+          action s2 {
+            requires { drug { "cocaine" } }
+          }
+        }
+      }
+      """
+      ast = parse_pml(pml)
+
+      assert Analysis.Ddis.run(ast, test_ddis(), test_drugs()) == [
+        %{
+          category: :alternative,
+          drug_a: "http://purl.com/paracetamol",
+          drug_b: "http://purl.com/cocaine",
+          enclosing_construct: %{
+            type: :selection,
+            line: 2
+          }
+        }
+      ]
+    end
+
+    test "it can handle more complicated PML" do
+      pml = """
+      process proc {
+        selection {
+          action bar {
+            requires { drug { "paracetamol" } }
+          }
+          branch {
+            action baz {
+              requires { drug { "flat seven up" } }
+            }
+            action foo {
+              requires { drug { "cocaine" } }
+            }
+          }
+          sequence {
+            action s1 {
+              requires { drug { "heroin" } }
+            }
+            action s2 {
+              requires { drug { "skittles" } }
+            }
+          }
+        }
+      }
+      """
       ddis = [
         %{drug_a: "http://purl.com/paracetamol", drug_b: "http://purl.com/cocaine"},
         %{drug_a: "http://purl.com/cocaine", drug_b: "http://purl.com/flat_seven_up"},
@@ -47,12 +141,36 @@ defmodule Panacea.Pml.Analysis.DdisTest do
         %{label: "heroin", uri: "http://purl.com/heroin"},
         %{label: "skittles", uri: "http://purl.com/skittles"},
       ]
-      ast = test_ast()
+      ast = parse_pml(pml)
 
       assert Analysis.Ddis.run(ast, ddis, drugs) == [
-        %{type: :alternative, drug_a: "http://purl.com/paracetamol", drug_b: "http://purl.com/cocaine"},
-        %{type: :parallel, drug_a: "http://purl.com/cocaine", drug_b: "http://purl.com/flat_seven_up"},
-        %{type: :sequential, drug_a: "http://purl.com/heroin", drug_b: "http://purl.com/skittles"}
+        %{
+          category: :alternative,
+          drug_a: "http://purl.com/paracetamol",
+          drug_b: "http://purl.com/cocaine",
+          enclosing_construct: %{
+            type: :selection,
+            line: 2
+          }
+        },
+        %{
+          category: :parallel,
+          drug_a: "http://purl.com/cocaine",
+          drug_b: "http://purl.com/flat_seven_up",
+          enclosing_construct: %{
+            type: :branch,
+            line: 6
+          }
+        },
+        %{
+          category: :sequential,
+          drug_a: "http://purl.com/heroin",
+          drug_b: "http://purl.com/skittles",
+          enclosing_construct: %{
+            type: :sequence,
+            line: 14
+          }
+        }
       ]
     end
   end

--- a/panacea/test/panacea/pml/analysis/ddis_test.exs
+++ b/panacea/test/panacea/pml/analysis/ddis_test.exs
@@ -103,6 +103,47 @@ defmodule Panacea.Pml.Analysis.DdisTest do
       ]
     end
 
+    test "it can handle repeated drugs" do
+      pml = """
+      process repeated_drugs {
+        selection {
+          action s1 {
+            requires { drug { "paracetamol" } }
+          }
+          action s2 {
+            requires { drug { "cocaine" } }
+          }
+          action s3 {
+            requires { drug { "paracetamol" } }
+          }
+        }
+      }
+      """
+
+      ast = parse_pml(pml)
+
+      assert Analysis.Ddis.run(ast, test_ddis(), test_drugs()) == [
+        %{
+          "category" => :alternative,
+          "drug_a" => "http://purl.com/paracetamol",
+          "drug_b" => "http://purl.com/cocaine",
+          "enclosing_construct" => %{
+            "type" => :selection,
+            "line" => 2
+          }
+        },
+        %{
+          "category" => :alternative,
+          "drug_a" => "http://purl.com/paracetamol",
+          "drug_b" => "http://purl.com/cocaine",
+          "enclosing_construct" => %{
+            "type" => :selection,
+            "line" => 2
+          }
+        }
+      ]
+    end
+
     test "it can handle more complicated PML" do
       pml = """
       process proc {

--- a/panacea/web/controllers/asclepius_controller.ex
+++ b/panacea/web/controllers/asclepius_controller.ex
@@ -9,12 +9,30 @@ defmodule Panacea.AsclepiusController do
     |> Panacea.BaseController.respond(conn)
   end
 
-  def ddis(conn, %{"drugs" => drugs}) do
+  def ddis(conn, %{"ast" => ast, "drugs" => drugs}) when is_list(drugs) do
     drugs
+    |> Enum.map(fn %{"uri" => uri} -> uri end)
     |> Asclepius.ddis()
+    |> decode_ast(ast)
+    |> categorize_ddis(drugs)
     |> to_result(:ddis)
     |> Panacea.BaseController.respond(conn)
   end
+
+  defp decode_ast({:ok, ddis}, encoded_ast) do
+    case Panacea.Pml.Ast.decode(encoded_ast) do
+      {:ok, ast} ->
+        {:ok, ddis, ast}
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+  defp decode_ast({:error, reason}, _), do: {:error, reason}
+
+  defp categorize_ddis({:ok, ddis, ast}, drugs) do
+    {:ok, Panacea.Pml.Analysis.Ddis.run(ast, ddis, drugs)}
+  end
+  defp categorize_ddis({:error, reason}, _), do: {:error, reason}
 
   defp to_result({:ok, value}, key), do: {:ok, %{key => value}}
   defp to_result({:error, reason}, _),  do: {:error, reason}

--- a/panacea/web/controllers/ast_controller.ex
+++ b/panacea/web/controllers/ast_controller.ex
@@ -2,26 +2,9 @@ defmodule Panacea.AstController do
   use Panacea.Web, :controller
 
   def to_pml(conn, %{"ast" => encoded_ast}) do encoded_ast
-    |> decode()
-    |> to_erlang_term()
+    |> Panacea.Pml.Ast.decode()
     |> to_pml()
     |> respond(conn)
-  end
-
-  defp decode(encoded_ast) do
-    case Base.decode64(encoded_ast) do
-      {:ok, binary} ->
-        {:ok, binary}
-      :error ->
-        {:error, {:encoding_error, "AST is not base64 encoded."}}
-    end
-  end
-
-  defp to_erlang_term({:ok, binary}) do
-    {:ok, :erlang.binary_to_term(binary)}
-  end
-  defp to_erlang_term({:error, reason}) do
-    {:error, reason}
   end
 
   defp to_pml({:ok, ast}) do

--- a/panacea/web/static/js/app.js
+++ b/panacea/web/static/js/app.js
@@ -54,7 +54,6 @@ async function handleDrugsResponse(response) {
 
 async function handleUrisResponse(response, ast) {
   await handleResponse(response, async function ({uris: {found, not_found: unidentifiedDrugs}}) {
-    const uris = found.map(x => x.uri);
     const labels = found.map(x => x.label);
     const urisToLabels = found.reduce((acc, {uri, label}) => {
       acc[uri] = label;
@@ -71,9 +70,9 @@ async function handleUrisResponse(response, ast) {
       View.displayUnidentifiedDrugs(unidentifiedDrugs);
     }
 
-    if (uris.length > 1) {
+    if (found.length > 1) {
       try {
-        await handleDdisResponse(await Request.ddis(uris), urisToLabels);
+        await handleDdisResponse(await Request.ddis(found, ast), urisToLabels);
       } catch (e) {
         View.displayNetworkError(e);
       }

--- a/panacea/web/static/js/request.js
+++ b/panacea/web/static/js/request.js
@@ -22,8 +22,8 @@ export const uris = labels => {
   return post('/api/uris', JSON.stringify({labels}), defaultHeaders);
 };
 
-export const ddis = drugs => {
-  return post('/api/ddis', JSON.stringify({drugs}), defaultHeaders);
+export const ddis = (drugs, ast) => {
+  return post('/api/ddis', JSON.stringify({drugs, ast}), defaultHeaders);
 };
 
 export const generatePMLHref = ast => {


### PR DESCRIPTION
This adds the basic outline for categorizing DDIs. To do so it requires:

* an AST
* a list of DDIs `{drug_a, drug_b, ...}`
* a list of drugs `{uri, label}`

It iterates over the AST, mapping each drug to a list of the PML constructs it
is contained in (its `ancestors`).

For each DDI, it looks at the ancestors of the participating drugs, and gets
their intersection. It takes the common ancestor with the highest line number as
the `closest_common_ancestor`.

The type of this ancestor is used to categorize the DDI:

* `branch => parallel`
* `selection => alternative`
* `_ => sequential` # everything else

Caveats:

* does not yet handle drugs occurring more than once in a PML file
* does not yet properly handle multiple pml constructs on the same line:
  `task { task { ... } }`