### PR TITLE
generic error highlight generation

### DIFF
--- a/athloi/features/file_upload.feature
+++ b/athloi/features/file_upload.feature
@@ -39,15 +39,17 @@ Feature: File upload
     And I submit the upload form
     Then I should see the unnamed panel
     And I should see the following warnings in the unnamed panel:
-      | Unnamed task found on line 2 |
+      | task on line 2 |
 
   Scenario: uploading a PML file with clashing construct names
     When I select "analysis/clashes.pml"
     And I submit the upload form
     Then I should see the clashes panel
     And I should see the following warnings in the clashes panel:
-      | "baz" in action on line 3, action on line 9  |
-      | "baz2" in action on line 5, action on line 7 |
+      | action baz on line 3  |
+      | action baz on line 9  |
+      | action baz2 on line 5 |
+      | action baz2 on line 7 |
 
   Scenario: uploading a binary file
     When I select "example.png"

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable changes to this project will be documented in this file.
 - Parser now reports PML construct name clashes. These are then displayed to the
   user in a similar manner to other warnings.
 
+### Changed
+- Updated how warnings are displayed. Where possible, warnings now contain a
+  preview of the section of the PML file that caused the warning. This is
+  currently implemented for `Unnamed Constructs` and `PML Construct Name
+  Clashes`. We intend to use a similar design for other errors and warnings in
+  the future.
+
 ### Fixed
 - Running automated integration tests will now correctly test the release
   matching the current tag that is checked out.

--- a/panacea/lib/panacea/pml/ast.ex
+++ b/panacea/lib/panacea/pml/ast.ex
@@ -54,7 +54,7 @@ defmodule Panacea.Pml.Ast do
   defp get_with_default(attrs, key) do
     case Keyword.get(attrs, key) do
       nil -> ""
-      x   -> [" ", x]
+      x   -> [" ", to_string(x)]
     end
   end
 end

--- a/panacea/web/static/css/app.css
+++ b/panacea/web/static/css/app.css
@@ -45,7 +45,7 @@
   font-size: .8em;
   line-height: 1.4;
   white-space: normal;
-  font-family: menlo, consolas, monospace;
+  font-family: menlo, consolas, Ubuntu Mono, monospace;
   overflow: auto;
   max-width: 100%;
   border: none;
@@ -70,7 +70,7 @@
   user-select: none;
 }
 
-.clash-wrapper {
+.warning-wrapper {
   padding: 15px;
   margin: 10px;
   border: 1px solid #faebcc;

--- a/panacea/web/static/css/app.css
+++ b/panacea/web/static/css/app.css
@@ -38,3 +38,42 @@
 .padded-bottom {
   padding-bottom: 20px;
 }
+
+.code-block {
+  margin: 0;
+  padding: 12px 0;
+  font-size: .8em;
+  line-height: 1.4;
+  white-space: normal;
+  font-family: menlo, consolas, monospace;
+  overflow: auto;
+  max-width: 100%;
+  border: none;
+}
+
+.line {
+  white-space: pre;
+  display: block;
+  padding: 0 16px;
+}
+
+.highlighted {
+  background-color: #ffdcdc;
+}
+
+.ln {
+  color: #a0b0c0;
+  margin-right: 1.5em;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.clash-wrapper {
+  padding: 15px;
+  margin: 10px;
+  border: 1px solid #faebcc;
+  border-radius: 4px;
+  background: #fffffa;
+}

--- a/panacea/web/static/css/app.css
+++ b/panacea/web/static/css/app.css
@@ -45,7 +45,7 @@
   font-size: .8em;
   line-height: 1.4;
   white-space: normal;
-  font-family: menlo, consolas, Ubuntu Mono, monospace;
+  font-family: menlo, consolas, "Ubuntu Mono", monospace;
   overflow: auto;
   max-width: 100%;
   border: none;

--- a/panacea/web/static/js/app.js
+++ b/panacea/web/static/js/app.js
@@ -46,16 +46,17 @@ async function handleDrugsResponse(response) {
       View.displayNoDrugsError();
     }
 
-    // fetching the pml here, TODO: decide when is best to do this
-    const pml = await Request.pml(ast);
+    getFileContents(pml => {
+      const pmlLines = pml.split('\n');
 
-    if (unnamed.length > 0) {
-      View.displayUnnamed(unnamed, pml);
-    }
+      if (unnamed.length > 0) {
+        View.displayUnnamed(unnamed, pmlLines);
+      }
 
-    if (clashes.length > 0) {
-      View.displayClashes(clashes, pml);
-    }
+      if (clashes.length > 0) {
+        View.displayClashes(clashes, pmlLines);
+      }
+    });
   });
 }
 
@@ -94,3 +95,19 @@ async function handleDdisResponse(response, urisToLabels) {
     View.displayDdis(ddis, urisToLabels);
   });
 }
+
+const getFileContents = callback => {
+  const file = View.fileInputElement.files[0];
+  const fileName = file.name;
+  if (file) {
+    const reader = new FileReader();
+    reader.readAsText(file);
+    reader.onload = e => {
+      const contents = e.target.result;
+      callback(contents);
+    };
+  }
+  else {
+    throw 'file could not be read';
+  }
+};

--- a/panacea/web/static/js/app.js
+++ b/panacea/web/static/js/app.js
@@ -46,12 +46,15 @@ async function handleDrugsResponse(response) {
       View.displayNoDrugsError();
     }
 
+    // fetching the pml here, TODO: decide when is best to do this
+    const pml = await Request.pml(ast);
+
     if (unnamed.length > 0) {
-      View.displayUnnamed(unnamed);
+      View.displayUnnamed(unnamed, pml);
     }
 
     if (clashes.length > 0) {
-      View.displayClashes(clashes);
+      View.displayClashes(clashes, pml);
     }
   });
 }

--- a/panacea/web/static/js/app.js
+++ b/panacea/web/static/js/app.js
@@ -98,7 +98,6 @@ async function handleDdisResponse(response, urisToLabels) {
 
 const getFileContents = callback => {
   const file = View.fileInputElement.files[0];
-  const fileName = file.name;
   if (file) {
     const reader = new FileReader();
     reader.readAsText(file);

--- a/panacea/web/static/js/code-block.js
+++ b/panacea/web/static/js/code-block.js
@@ -1,4 +1,4 @@
-import * as Util from "./util"
+import * as Util from "./util";
 
 export const generate = (lines, highlightLineNumber, surroundingLines = 2) => {
   const highlightIndex = highlightLineNumber - 1;
@@ -8,34 +8,34 @@ export const generate = (lines, highlightLineNumber, surroundingLines = 2) => {
 
   const displayLines = lines.slice(startIndex, endIndex);
 
-  const codeBlock = Util.createElementWithClass('PRE', 'code-block');
+  const codeBlock = Util.createElementWithClass('pre', 'code-block');
 
   displayLines.forEach((lineContents, index) => {
     const lineNumber = startIndex + index + 1;
-    const isHighlighted = lineNumber == highlightLineNumber;
+    const isHighlighted = lineNumber === highlightLineNumber;
 
-    const line = generateLine(lineContents, lineNumber, isHighlighted)
+    const line = generateLine(lineContents, lineNumber, isHighlighted);
 
     codeBlock.appendChild(line);
-  })
+  });
 
   return codeBlock;
-}
+};
 
 const generateLine = (contents, lineNumber, isHighlighted) => {
-  const lineContainer = Util.createElementWithClass('SPAN', 'line');
+  const lineContainer = Util.createElementWithClass('span', 'line');
   if (isHighlighted) {
     lineContainer.classList.add('highlighted');
   }
 
-  const lineNumberSpan = Util.createElementWithClass('SPAN', 'ln');
+  const lineNumberSpan = Util.createElementWithClass('span', 'ln');
   lineNumberSpan.innerHTML = lineNumber;
 
-  const lineContentSpan = Util.createElementWithClass('SPAN', 'code');
+  const lineContentSpan = Util.createElementWithClass('span', 'code');
   lineContentSpan.innerHTML = contents;
 
   lineContainer.appendChild(lineNumberSpan);
   lineContainer.appendChild(lineContentSpan);
 
   return lineContainer;
-}
+};

--- a/panacea/web/static/js/code-block.js
+++ b/panacea/web/static/js/code-block.js
@@ -4,9 +4,9 @@ export const generate = (lines, highlightLineNumber, surroundingLines = 2) => {
   const highlightIndex = highlightLineNumber - 1;
 
   const startIndex = Math.max(0, highlightIndex - surroundingLines);
-  const endIndex   = Math.min(lines.length - 1, highlightIndex + surroundingLines) + 1;
+  const endIndex   = Math.min(lines.length - 1, highlightIndex + surroundingLines);
 
-  const displayLines = lines.slice(startIndex, endIndex);
+  const displayLines = lines.slice(startIndex, endIndex + 1);
 
   const codeBlock = Util.createElementWithClass('pre', 'code-block');
 

--- a/panacea/web/static/js/code-block.js
+++ b/panacea/web/static/js/code-block.js
@@ -1,0 +1,41 @@
+import * as Util from "./util"
+
+export const generate = (lines, highlightLineNumber, surroundingLines = 2) => {
+  const highlightIndex = highlightLineNumber - 1;
+
+  const startIndex = Math.max(0, highlightIndex - surroundingLines);
+  const endIndex   = Math.min(lines.length - 1, highlightIndex + surroundingLines) + 1;
+
+  const displayLines = lines.slice(startIndex, endIndex);
+
+  const codeBlock = Util.createElementWithClass('PRE', 'code-block');
+
+  displayLines.forEach((lineContents, index) => {
+    const lineNumber = startIndex + index + 1;
+    const isHighlighted = lineNumber == highlightLineNumber;
+
+    const line = generateLine(lineContents, lineNumber, isHighlighted)
+
+    codeBlock.appendChild(line);
+  })
+
+  return codeBlock;
+}
+
+const generateLine = (contents, lineNumber, isHighlighted) => {
+  const lineContainer = Util.createElementWithClass('SPAN', 'line');
+  if (isHighlighted) {
+    lineContainer.classList.add('highlighted');
+  }
+
+  const lineNumberSpan = Util.createElementWithClass('SPAN', 'ln');
+  lineNumberSpan.innerHTML = lineNumber;
+
+  const lineContentSpan = Util.createElementWithClass('SPAN', 'code');
+  lineContentSpan.innerHTML = contents;
+
+  lineContainer.appendChild(lineNumberSpan);
+  lineContainer.appendChild(lineContentSpan);
+
+  return lineContainer;
+}

--- a/panacea/web/static/js/request.js
+++ b/panacea/web/static/js/request.js
@@ -32,8 +32,3 @@ export const generatePMLHref = ast => {
   const tokenParam = `authorization_token=${encodeURIComponent(apiAccessToken)}`;
   return `${endpoint}?${astParam}&${tokenParam}`;
 };
-
-export async function pml(ast) {
-  const resp = await fetch(generatePMLHref(ast), { method: 'GET' });
-  return resp.text();
-}

--- a/panacea/web/static/js/request.js
+++ b/panacea/web/static/js/request.js
@@ -32,3 +32,8 @@ export const generatePMLHref = ast => {
   const tokenParam = `authorization_token=${encodeURIComponent(apiAccessToken)}`;
   return `${endpoint}?${astParam}&${tokenParam}`;
 };
+
+export async function pml(ast) {
+  const resp = await fetch(generatePMLHref(ast), { method: 'GET' });
+  return resp.text();
+}

--- a/panacea/web/static/js/util.js
+++ b/panacea/web/static/js/util.js
@@ -1,0 +1,6 @@
+export const createElementWithClass = (elementName, className) => {
+  const element = document.createElement(elementName);
+  element.classList.add(className);
+  return element;
+}
+

--- a/panacea/web/static/js/util.js
+++ b/panacea/web/static/js/util.js
@@ -2,5 +2,5 @@ export const createElementWithClass = (elementName, className) => {
   const element = document.createElement(elementName);
   element.classList.add(className);
   return element;
-}
+};
 

--- a/panacea/web/static/js/view.js
+++ b/panacea/web/static/js/view.js
@@ -1,11 +1,12 @@
-const drugsPanel             = document.getElementById('drugs-panel');
-const unidentifiedDrugsPanel = document.getElementById('unidentified-drugs-panel');
-const ddisPanel              = document.getElementById('ddis-panel');
-const errorPanel             = document.getElementById('error-panel');
-const unnamedPanel           = document.getElementById('unnamed-panel');
-const clashesPanel           = document.getElementById('clashes-panel');
-const pmlDownloadContainer   = document.getElementById('pml-download-container');
-const pmlDownloadAnchor      = document.getElementById('pml-download-anchor');
+const drugsPanel              = document.getElementById('drugs-panel');
+const unidentifiedDrugsPanel  = document.getElementById('unidentified-drugs-panel');
+const ddisPanel               = document.getElementById('ddis-panel');
+const errorPanel              = document.getElementById('error-panel');
+const unnamedPanel            = document.getElementById('unnamed-panel');
+const clashesPanel            = document.getElementById('clashes-panel');
+const pmlDownloadContainer    = document.getElementById('pml-download-container');
+const pmlDownloadAnchor       = document.getElementById('pml-download-anchor');
+export const fileInputElement = document.getElementById('file-input');
 
 const hideElement = element => {
   element.classList.add('hidden');
@@ -33,7 +34,7 @@ export const displayDrugs = drugs => {
   showElement(drugsPanel);
 };
 
-export const displayUnnamed = (unnamed, pml) => {
+export const displayUnnamed = (unnamed, pmlLines) => {
   const unnamedTextElement = document.getElementById('unnamed-text');
   unnamedTextElement.innerHTML = '';
 
@@ -45,13 +46,13 @@ export const displayUnnamed = (unnamed, pml) => {
     const details = document.createElement('STRONG');
     details.innerHTML = `Unnamed ${construct.type} found on line ${construct.line}:`;
     unnamedTextElement.appendChild(details);
-    unnamedTextElement.appendChild(generateErrorHighlight(pml, construct.line));
+    unnamedTextElement.appendChild(generateErrorHighlight(pmlLines, construct.line));
   }
 
   showElement(unnamedPanel);
 };
 
-export const displayClashes = (clashes, pml) => {
+export const displayClashes = (clashes, pmlLines) => {
   const clashesTextElement = document.getElementById('clashes-text');
   clashesTextElement.innerHTML = '';
 
@@ -62,14 +63,13 @@ export const displayClashes = (clashes, pml) => {
   for (const clash of clashes) {
     const sorted = clash.occurrences.sort((a, b) => a.line - b.line);
 
-    const wrapper = document.createElement('DIV');
-    wrapper.classList.add('clash-wrapper');
+    const wrapper = createElementWithClass('DIV', 'clash-wrapper');
 
     for (const occurrence of sorted) {
       const details = document.createElement('STRONG');
       details.innerHTML = `${occurrence.type} ${clash.name} found on line ${occurrence.line}:`;
       wrapper.appendChild(details);
-      wrapper.appendChild(generateErrorHighlight(pml, occurrence.line));
+      wrapper.appendChild(generateErrorHighlight(pmlLines, occurrence.line));
     }
 
     clashesTextElement.appendChild(wrapper);
@@ -156,8 +156,7 @@ export const restoreFileForm = () => {
   hideElement(loadingElement);
 };
 
-export const generateErrorHighlight = (code, errorLine, numContextLines = 2) => {
-  const lines = code.split('\n');
+const generateErrorHighlight = (lines, errorLine, numContextLines = 2) => {
   const errorlineIndex = errorLine - 1;
 
   const startIndex = Math.max(0, errorlineIndex - numContextLines);
@@ -198,7 +197,6 @@ const createElementWithClass = (elementName, className) => {
 // to make the file input pretty take the filename from the form
 // and place it in a disabled input box right beside it :art:
 const filenameDisplayElement = document.getElementById('filename-display');
-const fileInputElement = document.getElementById('file-input');
 fileInputElement.addEventListener('change', function(e) {
   filenameDisplayElement.value = this.files[0].name;
   hideResults();

--- a/panacea/web/static/js/view.js
+++ b/panacea/web/static/js/view.js
@@ -1,3 +1,6 @@
+import * as CodeBlock from "./code-block"
+import * as Util from "./util"
+
 const drugsPanel              = document.getElementById('drugs-panel');
 const unidentifiedDrugsPanel  = document.getElementById('unidentified-drugs-panel');
 const ddisPanel               = document.getElementById('ddis-panel');
@@ -46,7 +49,7 @@ export const displayUnnamed = (unnamed, pmlLines) => {
     const details = document.createElement('STRONG');
     details.innerHTML = `Unnamed ${construct.type} found on line ${construct.line}:`;
     unnamedTextElement.appendChild(details);
-    unnamedTextElement.appendChild(generateErrorHighlight(pmlLines, construct.line));
+    unnamedTextElement.appendChild(CodeBlock.generate(pmlLines, construct.line));
   }
 
   showElement(unnamedPanel);
@@ -63,13 +66,13 @@ export const displayClashes = (clashes, pmlLines) => {
   for (const clash of clashes) {
     const sorted = clash.occurrences.sort((a, b) => a.line - b.line);
 
-    const wrapper = createElementWithClass('DIV', 'clash-wrapper');
+    const wrapper = Util.createElementWithClass('DIV', 'clash-wrapper');
 
     for (const occurrence of sorted) {
       const details = document.createElement('STRONG');
       details.innerHTML = `${occurrence.type} ${clash.name} found on line ${occurrence.line}:`;
       wrapper.appendChild(details);
-      wrapper.appendChild(generateErrorHighlight(pmlLines, occurrence.line));
+      wrapper.appendChild(CodeBlock.generate(pmlLines, occurrence.line));
     }
 
     clashesTextElement.appendChild(wrapper);
@@ -155,44 +158,6 @@ export const restoreFileForm = () => {
   showElement(formElement);
   hideElement(loadingElement);
 };
-
-const generateErrorHighlight = (lines, errorLine, numContextLines = 2) => {
-  const errorlineIndex = errorLine - 1;
-
-  const startIndex = Math.max(0, errorlineIndex - numContextLines);
-  const endIndex = Math.min(lines.length-1, errorlineIndex + numContextLines);
-  const displayLines = lines.slice(startIndex, endIndex + 1); // slice extracts up to but not including end
-
-  const codeBlockElement = createElementWithClass('PRE','code-block');
-
-  displayLines.forEach((lineContents, currentIndex) => {
-    const currentLineIndex = startIndex + currentIndex;
-    const currentLineNum = currentLineIndex + 1;
-
-    const lineContainer = createElementWithClass('SPAN', 'line');
-    if (currentLineIndex === errorlineIndex) {
-      lineContainer.classList.add('highlighted');
-    }
-
-    const lineNumberSpan = createElementWithClass('SPAN', 'ln');
-    lineNumberSpan.innerHTML = currentLineNum;
-
-    const lineContentSpan = createElementWithClass('SPAN', 'code');
-    lineContentSpan.innerHTML = lineContents;
-
-    lineContainer.appendChild(lineNumberSpan);
-    lineContainer.appendChild(lineContentSpan);
-    codeBlockElement.appendChild(lineContainer);
-  });
-
-  return codeBlockElement;
-};
-
-const createElementWithClass = (elementName, className) => {
-  const element = document.createElement(elementName);
-  element.classList.add(className);
-  return element;
-}
 
 // to make the file input pretty take the filename from the form
 // and place it in a disabled input box right beside it :art:

--- a/panacea/web/static/js/view.js
+++ b/panacea/web/static/js/view.js
@@ -37,51 +37,52 @@ export const displayDrugs = drugs => {
   showElement(drugsPanel);
 };
 
-export const displayUnnamed = (unnamed, pmlLines) => {
-  const unnamedTextElement = document.getElementById('unnamed-text');
-  unnamedTextElement.innerHTML = '';
+const displayWarnings = (container, preambleText, warnings, pml) => {
+  container.innerHTML = '';
 
   const preamble = document.createElement('p');
-  preamble.innerHTML = 'I found the following unnamed PML constructs:';
-  unnamedTextElement.appendChild(preamble);
+  preamble.innerHTML = preambleText;
+  container.appendChild(preamble);
 
-  for (const construct of unnamed) {
+  for (const warning of warnings) {
     const wrapper = Util.createElementWithClass('div', 'warning-wrapper');
 
-    const details = document.createElement('strong');
-    details.innerHTML = `${construct.type} on line ${construct.line}:`;
-    wrapper.appendChild(details);
-    wrapper.appendChild(CodeBlock.generate(pmlLines, construct.line));
+    for (const member of warning) {
+      const details = document.createElement('strong');
+      details.innerHTML = `${member.identifier} on line ${member.line}`;
+      wrapper.appendChild(details);
 
-    unnamedTextElement.appendChild(wrapper);
+      const codeBlock = CodeBlock.generate(pml, member.line);
+      wrapper.appendChild(codeBlock);
+    }
+
+    container.appendChild(wrapper);
   }
+};
 
+export const displayUnnamed = (unnamed, pmlLines) => {
+  const container = document.getElementById('unnamed-text');
+  const preamble = 'I found the following unnamed PML constructs:';
+  const warnings = unnamed.map(({type, line}) => {
+    return [{line, identifier: type}];
+  });
+
+  displayWarnings(container, preamble, warnings, pmlLines);
   showElement(unnamedPanel);
 };
 
 export const displayClashes = (clashes, pmlLines) => {
-  const clashesTextElement = document.getElementById('clashes-text');
-  clashesTextElement.innerHTML = '';
+  const container = document.getElementById('clashes-text');
+  const preamble = 'I found the following PML construct name clashes:';
+  const warnings = clashes.map(({occurrences, name}) => {
+    return occurrences
+      .sort((a, b) => a.line - b.line)
+      .map(({type, line}) => {
+        return {line, identifier: `${type} ${name}`};
+      });
+  });
 
-  const preamble = document.createElement('p');
-  preamble.innerHTML = 'I found the following PML construct name clashes:';
-  clashesTextElement.appendChild(preamble);
-
-  for (const clash of clashes) {
-    const sorted = clash.occurrences.sort((a, b) => a.line - b.line);
-
-    const wrapper = Util.createElementWithClass('div', 'warning-wrapper');
-
-    for (const occurrence of sorted) {
-      const details = document.createElement('strong');
-      details.innerHTML = `${occurrence.type} ${clash.name} on line ${occurrence.line}:`;
-      wrapper.appendChild(details);
-      wrapper.appendChild(CodeBlock.generate(pmlLines, occurrence.line));
-    }
-
-    clashesTextElement.appendChild(wrapper);
-  }
-
+  displayWarnings(container, preamble, warnings, pmlLines);
   showElement(clashesPanel);
 };
 

--- a/panacea/web/static/js/view.js
+++ b/panacea/web/static/js/view.js
@@ -1,5 +1,5 @@
-import * as CodeBlock from "./code-block"
-import * as Util from "./util"
+import * as CodeBlock from "./code-block";
+import * as Util from "./util";
 
 const drugsPanel              = document.getElementById('drugs-panel');
 const unidentifiedDrugsPanel  = document.getElementById('unidentified-drugs-panel');
@@ -41,15 +41,19 @@ export const displayUnnamed = (unnamed, pmlLines) => {
   const unnamedTextElement = document.getElementById('unnamed-text');
   unnamedTextElement.innerHTML = '';
 
-  const preamble = document.createElement('P');
+  const preamble = document.createElement('p');
   preamble.innerHTML = 'I found the following unnamed PML constructs:';
   unnamedTextElement.appendChild(preamble);
 
   for (const construct of unnamed) {
-    const details = document.createElement('STRONG');
-    details.innerHTML = `Unnamed ${construct.type} found on line ${construct.line}:`;
-    unnamedTextElement.appendChild(details);
-    unnamedTextElement.appendChild(CodeBlock.generate(pmlLines, construct.line));
+    const wrapper = Util.createElementWithClass('div', 'warning-wrapper');
+
+    const details = document.createElement('strong');
+    details.innerHTML = `${construct.type} on line ${construct.line}:`;
+    wrapper.appendChild(details);
+    wrapper.appendChild(CodeBlock.generate(pmlLines, construct.line));
+
+    unnamedTextElement.appendChild(wrapper);
   }
 
   showElement(unnamedPanel);
@@ -59,18 +63,18 @@ export const displayClashes = (clashes, pmlLines) => {
   const clashesTextElement = document.getElementById('clashes-text');
   clashesTextElement.innerHTML = '';
 
-  const preamble = document.createElement('P');
+  const preamble = document.createElement('p');
   preamble.innerHTML = 'I found the following PML construct name clashes:';
   clashesTextElement.appendChild(preamble);
 
   for (const clash of clashes) {
     const sorted = clash.occurrences.sort((a, b) => a.line - b.line);
 
-    const wrapper = Util.createElementWithClass('DIV', 'clash-wrapper');
+    const wrapper = Util.createElementWithClass('div', 'warning-wrapper');
 
     for (const occurrence of sorted) {
-      const details = document.createElement('STRONG');
-      details.innerHTML = `${occurrence.type} ${clash.name} found on line ${occurrence.line}:`;
+      const details = document.createElement('strong');
+      details.innerHTML = `${occurrence.type} ${clash.name} on line ${occurrence.line}:`;
       wrapper.appendChild(details);
       wrapper.appendChild(CodeBlock.generate(pmlLines, occurrence.line));
     }

--- a/panacea/web/templates/page/index.html.eex
+++ b/panacea/web/templates/page/index.html.eex
@@ -17,6 +17,11 @@
   </div>
 </form>
 
+<div class="panel panel-danger hidden fades-in" id="error-panel">
+  <div class="panel-heading" id="error-title"></div>
+  <div class="panel-body" id="error-text"></div>
+</div>
+
 <div class="panel panel-success hidden fades-in" id="drugs-panel">
   <div class="panel-heading">Drugs Found</div>
   <div class="panel-body" id="drugs-text"></div>
@@ -40,11 +45,6 @@
 <div class="panel panel-success hidden fades-in" id="ddis-panel">
   <div class="panel-heading">Drug-Drug Interactions</div>
   <div class="panel-body" id="ddis-text"></div>
-</div>
-
-<div class="panel panel-danger hidden fades-in" id="error-panel">
-  <div class="panel-heading" id="error-title"></div>
-  <div class="panel-body" id="error-text"></div>
 </div>
 
 <div class="center hidden padded-bottom fades-in" id="pml-download-container">


### PR DESCRIPTION
I've added a function that takes a source file and a line number (and optionally a number to indicate the number of surrounding lines to display above and below the highlighted line), and returns a pre-formatted DOM element.

It looks like this:
<img width="674" alt="screen shot 2017-03-25 at 03 49 02" src="https://cloud.githubusercontent.com/assets/7144173/24319257/2396c3d4-110e-11e7-88ef-68e1f6c0fc17.png">

To show it in use I've modified the `displayClashes` and `displayUnnamed` view functions to use it, those look like this:

<img width="749" alt="screen shot 2017-03-25 at 03 48 29" src="https://cloud.githubusercontent.com/assets/7144173/24319263/49241e44-110e-11e7-8500-e41e19f7a8a8.png">

I've done it this way to try and decouple the error highlighting logic from the bootstrap panels in order to make it easy to port to whatever UI we decide to go with because I don't like how it looks at the moment, much too bulky.
