### PR TITLE
adds line numbers to syntax errors

### DIFF
--- a/panacea/lib/panacea/pml/parser.ex
+++ b/panacea/lib/panacea/pml/parser.ex
@@ -23,11 +23,11 @@ defmodule Panacea.Pml.Parser do
     {:error, reason}
   end
 
-  defp log_result({:error, reason}) do
+  defp log_result({:error, reason = {line, _, _}}) do
     formatted = Error.format(reason)
     Logger.error("PML Parsing error: #{formatted}")
 
-    {:error, {:syntax_error, formatted}}
+    {:error, {:syntax_error, formatted, %{line: line}}}
   end
   defp log_result({:ok, ast}) do
     Logger.info("PML Analysis success")

--- a/panacea/test/error_test.exs
+++ b/panacea/test/error_test.exs
@@ -4,6 +4,16 @@ defmodule Panacea.Web.ErrorTest do
 
   describe "from_reason/1" do
     test "it generates a nice error" do
+      assert {:invalid_data, "foo", %{line: 10}} |> Error.from_reason ==
+        %Error{
+          status_code: :unprocessable_entity,
+          title: "Invalid data",
+          detail: "foo",
+          meta: %{line: 10}
+        }
+    end
+
+    test "meta defaults to an empty map when no metadata is provided" do
       assert {:invalid_data, "foo"} |> Error.from_reason ==
         %Error{
           status_code: :unprocessable_entity,
@@ -17,12 +27,6 @@ defmodule Panacea.Web.ErrorTest do
   describe "title/1" do
     test "it converts the atom to a sentence" do
       assert Error.title(:encoding_error) == "Encoding error"
-    end
-  end
-
-  describe "meta/2" do
-    test "it generates a map of metadata for the error" do
-      assert Error.meta(:invalid_data, "foo") == %{}
     end
   end
 

--- a/panacea/test/panacea/pml/parser_test.exs
+++ b/panacea/test/panacea/pml/parser_test.exs
@@ -39,7 +39,13 @@ defmodule Panacea.Pml.ParserTest do
       process foo {{
       """
 
-      assert Parser.parse(pml) == {:error,  {:syntax_error, "line 1 -- syntax error before: '{'"}}
+      assert Parser.parse(pml) == { :error,
+        {
+          :syntax_error,
+          "line 1 -- syntax error before: '{'",
+          %{line: 1}
+        }
+      }
     end
   end
 end

--- a/panacea/web/error.ex
+++ b/panacea/web/error.ex
@@ -2,12 +2,15 @@ defmodule Panacea.Web.Error do
   defstruct [:status_code, :title, :detail, :meta]
   alias __MODULE__
 
-  def from_reason({type, message}) do
-    %Error{
+  def from_reason({type, message}), do: new(type, message, %{})
+  def from_reason({type, message, meta}) when is_map(meta), do: new(type, message, meta)
+
+  defp new(type, message, meta) do
+   %Error{
       status_code: status_code(type),
       title: title(type),
       detail: message,
-      meta: meta(type, message)
+      meta: meta
     }
   end
 
@@ -29,6 +32,4 @@ defmodule Panacea.Web.Error do
     |> String.replace("_", " ")
     |> String.capitalize()
   end
-
-  def meta(_, _), do: %{}
 end


### PR DESCRIPTION
* `Web.Error` now takes the metadata as an argument
* `Parser` now adds metadata to the errors it generates - `%{line: line_number}`