### PR TITLE
DDI enrichment

### DIFF
--- a/panacea/README.md
+++ b/panacea/README.md
@@ -135,8 +135,16 @@ Tokens can be generated using: `Panacea.AccessToken.generate()`
 {
   "ddis": [
     {
-      "drug_a": "http://purl.obolibrary.org/obo/DINTO_DB00214",
-      "drug_b": "http://purl.obolibrary.org/obo/DINTO_DB00519",
+      "drug_a": {
+        "uri": "http://purl.obolibrary.org/obo/DINTO_DB00214",
+        "label": "torasemide",
+        "line": 3
+      },
+      "drug_b": {
+        "uri": "http://purl.obolibrary.org/obo/DINTO_DB00519",
+        "label": "trandolapril",
+        "line": 6
+      },
       "label": "torasemide/trandolapril DDI",
       "uri": "http://purl.obolibrary.org/obo/DINTO_11031",
       "harmful": false,

--- a/panacea/test/controllers/asclepius_controller_test.exs
+++ b/panacea/test/controllers/asclepius_controller_test.exs
@@ -102,8 +102,16 @@ defmodule Panacea.AsclepiusControllerTest do
         [
           %{
             "category" => "sequential",
-            "drug_a" => "http://purl.obolibrary.org/obo/DINTO_DB00214",
-            "drug_b" => "http://purl.obolibrary.org/obo/DINTO_DB00519",
+            "drug_a" => %{
+              "uri" => "http://purl.obolibrary.org/obo/DINTO_DB00214",
+              "label" => "torasemide",
+              "line" => 3
+            },
+            "drug_b" => %{
+              "uri" => "http://purl.obolibrary.org/obo/DINTO_DB00519",
+              "label" => "trandolapril",
+              "line" => 6
+            },
             "label" => "torasemide/trandolapril DDI",
             "uri"   => "http://purl.obolibrary.org/obo/DINTO_11031",
             "enclosing_constructs" => [

--- a/panacea/test/panacea/pml/analysis/ddis_test.exs
+++ b/panacea/test/panacea/pml/analysis/ddis_test.exs
@@ -119,7 +119,7 @@ defmodule Panacea.Pml.Analysis.DdisTest do
       assert ddis |> Enum.count() == 2
     end
 
-    test "it adds the correct drug metadata" do
+    test "it adds the correct DDI metadata" do
       pml = """
       process repeated_alternative_ddis {
         iteration {
@@ -137,6 +137,8 @@ defmodule Panacea.Pml.Analysis.DdisTest do
       ast = parse_pml(pml)
       [ddi] = Ddis.run(ast, test_ddis(), test_drugs())
 
+      assert ddi["category"] == :repeated_alternative
+
       assert ddi["drug_a"] == %{
         "uri" => "http://purl.com/paracetamol",
         "label" => "paracetamol",
@@ -148,6 +150,11 @@ defmodule Panacea.Pml.Analysis.DdisTest do
         "label" => "cocaine",
         "line" => 8
       }
+
+      assert ddi["enclosing_constructs"] == [
+        %{ "type" => :selection, "line" => 3 },
+        %{ "type" => :iteration, "line" => 2 }
+      ]
     end
   end
 end

--- a/panacea/web/static/js/app.js
+++ b/panacea/web/static/js/app.js
@@ -63,10 +63,6 @@ async function handleDrugsResponse(response) {
 async function handleUrisResponse(response, ast) {
   await handleResponse(response, async function ({uris: {found, not_found: unidentifiedDrugs}}) {
     const labels = found.map(x => x.label);
-    const urisToLabels = found.reduce((acc, {uri, label}) => {
-      acc[uri] = label;
-      return acc;
-    }, {});
 
     View.preparePMLDownloadButton(Request.generatePMLHref(ast));
 
@@ -80,7 +76,7 @@ async function handleUrisResponse(response, ast) {
 
     if (found.length > 1) {
       try {
-        await handleDdisResponse(await Request.ddis(found, ast), urisToLabels);
+        await handleDdisResponse(await Request.ddis(found, ast));
       } catch (e) {
         View.displayNetworkError(e);
       }
@@ -90,9 +86,9 @@ async function handleUrisResponse(response, ast) {
   });
 }
 
-async function handleDdisResponse(response, urisToLabels) {
+async function handleDdisResponse(response) {
   await handleResponse(response, ({ddis}) => {
-    View.displayDdis(ddis, urisToLabels);
+    View.displayDdis(ddis);
   });
 }
 

--- a/panacea/web/static/js/view.js
+++ b/panacea/web/static/js/view.js
@@ -108,16 +108,16 @@ export const displayUnidentifiedDrugs = drugs => {
   showElement(unidentifiedDrugsPanel);
 };
 
-export const displayDdis = (ddis, urisToLabels) => {
+export const displayDdis = (ddis) => {
   const ddisTextElement = document.getElementById('ddis-text');
 
   if (ddis.length > 0) {
     const preamble = 'I have identified interactions between the following drugs:';
-    const ddisHTML = ddis.map(({drug_a: uriA, drug_b: uriB}) => {
-      const drugA = urisToLabels[uriA];
-      const drugB = urisToLabels[uriB];
+    const ddisHTML = ddis.map(({drug_a, drug_b}) => {
+      const labelA = drug_a.label;
+      const labelB = drug_b.label;
 
-      return `<li><strong>${drugA}</strong> and <strong>${drugB}</strong></li>`;
+      return `<li><strong>${labelA}</strong> and <strong>${labelB}</strong></li>`;
     }).join('');
 
     ddisTextElement.innerHTML = `<p>${preamble}</p><ul>${ddisHTML}</ul>`;


### PR DESCRIPTION
Adds the line number and label for each drug to the `/api/ddis` response.

We will need the line numbers for highlighting the drugs in the file and returning the label simplifies the frontend logic a bit.

As per [this section](https://github.com/tom-and-the-toothfairies/pathways/tree/ddi-enrichment/panacea#response-body-2) of the updated README, the `/apis/ddis` response now has this structure:

```json
{
  "ddis": [
    {
      "drug_a": {
        "uri": "http://purl.obolibrary.org/obo/DINTO_DB00214",
        "label": "torasemide",
        "line": 3
      },
      "drug_b": {
        "uri": "http://purl.obolibrary.org/obo/DINTO_DB00519",
        "label": "trandolapril",
        "line": 6
      },
      "label": "torasemide/trandolapril DDI",
      "uri": "http://purl.obolibrary.org/obo/DINTO_11031",
      "harmful": false,
      "spacing": 3,
      "category": "sequential",
      "enclosing_constructs": [
        {
          "type": "sequence",
          "line": 6
        }
      ]
    }
  ]
}
```

Previously, `drug_a` and `drug_b` were just strings (the DINTO uri for the drug).